### PR TITLE
feat(sim): pure fixed-timestep physics core (Phase 0-1 foundation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "astro dev",
     "data:split": "node scripts/split_story_data.mjs && node scripts/split_skin_data.mjs && node scripts/split_simulator_data.mjs && node scripts/split_skin_poll_data.mjs",
     "check:versions": "node scripts/check-versions.mjs",
+    "test": "node --test",
     "build": "npm run check:versions && npm run data:split && astro build && node scripts/minify.mjs",
     "build:no-minify": "npm run check:versions && astro build",
     "preview": "astro preview",

--- a/public/js/simulators/physics/bullet-registry.js
+++ b/public/js/simulators/physics/bullet-registry.js
@@ -1,0 +1,20 @@
+/**
+ * physics/bullet-registry.js
+ * Maps a game bullet `type` to its BulletUnit subclass and constructs it.
+ * Mirrors the game's GetFactoryList()[type] dispatch. Later phases register
+ * bomb (2), torpedo (3), shrapnel (5), missile (13), scale (15), etc.
+ */
+
+import { BulletUnit } from './bullet-unit.js';
+import { CannonBulletUnit } from './bullets/cannon.js';
+
+const BULLET_CLASSES = {
+  1: CannonBulletUnit,  // CANNON
+  8: CannonBulletUnit,  // STRAY — same straight-line movement
+};
+
+/** Construct the BulletUnit subclass for `type`, forwarding `opts`. */
+export function createBulletUnit(type, opts) {
+  const Cls = BULLET_CLASSES[type] ?? BulletUnit;
+  return new Cls(opts);
+}

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -9,6 +9,7 @@
  */
 
 import { BULLET_SPEED_CONVERT } from './constants.js';
+import { sqrDistance } from './vec.js';
 
 const DEG_TO_RAD = Math.PI / 180;
 
@@ -65,5 +66,48 @@ export class BulletUnit {
       : this._baseRange + this._rangeOffset * (this.rng() - 0.5);
     this.range = Math.max(0, this.range);
     this.sqrRange = this.range * this.range;
+  }
+
+  /**
+   * Pick the single per-tick movement function. Mirrors InitSpeed
+   * (battlebulletunit.lua:738-768). The game's priority chain is
+   * HasAcceleration -> doAccelerate, IsTracker -> doTrack, IsCircle -> doCircle,
+   * else doNothing. Acceleration/tracker/circle are added in Phase 2; for now
+   * every bullet resolves to doNothing.
+   */
+  InitSpeed() {
+    this.calcSpeed();
+    this.updateSpeed = this.doNothing;
+  }
+
+  /**
+   * The movement function for a non-accel/track/circle bullet. Mirrors doNothing
+   * (battlebulletunit.lua:115-119): it is the gravity integrator. GetSpeedRatio()
+   * is 1 in all default cases, so it is omitted.
+   */
+  doNothing() {
+    if (this.gravity !== 0) {
+      this.verticalSpeed += this.gravity;
+    }
+  }
+
+  /**
+   * Advance the bullet one fixed tick. Mirrors Update (battlebulletunit.lua:
+   * 139-157): run the chosen movement function, integrate position by `speed`
+   * and altitude by `verticalSpeed`, then test range expiry.
+   *
+   * Only the non-gravity (`gravity === 0`) expiry branch is implemented here;
+   * the gravity-bullet detonation branch (`altitude <= BombDetonateHeight`)
+   * arrives with the bomb work in Phase 2.
+   */
+  Update() {
+    this.updateSpeed();
+    this.position.x += this.speed.x;
+    this.position.y += this.speed.y;
+    this.altitude += this.verticalSpeed;
+
+    if (this.gravity === 0) {
+      this.reachDestFlag = this.sqrRange < sqrDistance(this.spawnPos, this.position);
+    }
   }
 }

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -1,0 +1,69 @@
+/**
+ * physics/bullet-unit.js
+ * BulletUnit — the base bullet, mirroring the game's BattleBulletUnit
+ * (battlebulletunit.lua). Pure: no DOM, no wall-clock. One simulation tick
+ * advances the unit by exactly 1/30 game-second.
+ *
+ * Coordinate model: `position {x, y}` is the horizontal battlefield plane
+ * (the game's x/z); `altitude` is the vertical axis (the game's _position.y).
+ */
+
+import { BULLET_SPEED_CONVERT } from './constants.js';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+export class BulletUnit {
+  constructor(opts = {}) {
+    this.type = opts.type ?? 1;
+    this.velocity = opts.velocity ?? 0;       // base data velocity
+    this.yAngle = opts.yAngle ?? 0;           // heading, degrees
+    this.gravity = opts.gravity ?? 0;         // 0 for cannon
+    this.rng = opts.rng ?? Math.random;
+
+    this._baseRange = opts.range ?? 0;
+    this._rangeOffset = opts.rangeOffset ?? 0;
+
+    const sx = opts.spawnX ?? 0;
+    const sy = opts.spawnY ?? 0;
+    this.position = { x: sx, y: sy };
+    this.spawnPos = { x: sx, y: sy };
+
+    this.speed = { x: 0, y: 0 };  // per-tick horizontal displacement vector
+    this.verticalSpeed = 0;       // per-tick altitude change
+    this.altitude = opts.spawnAltitude ?? 0;
+
+    this.range = 0;
+    this.sqrRange = 0;
+    this.timeElapsed = 0;
+    this.reachDestFlag = false;
+  }
+
+  /**
+   * Build the per-tick speed vector from the data velocity and heading.
+   * Mirrors calcSpeed (battlebulletunit.lua:780-782). The game also multiplies
+   * by (1 + bulletSpeedRatio); the simulator has no buff system, so that term
+   * is its identity value (1) and is omitted.
+   */
+  calcSpeed() {
+    const rad = this.yAngle * DEG_TO_RAD;
+    const converted = this.velocity * BULLET_SPEED_CONVERT;
+    this.speed = {
+      x: converted * Math.cos(rad),
+      y: converted * Math.sin(rad),
+    };
+  }
+
+  /**
+   * Resolve the effective range. Mirrors FixRange (battlebulletunit.lua:819-831):
+   *   range_offset == 0  ->  range unchanged
+   *   else               ->  range + range_offset * (random() - 0.5)
+   * then clamp to >= 0. sqrRange is cached for the squared-distance expiry test.
+   */
+  FixRange() {
+    this.range = this._rangeOffset === 0
+      ? this._baseRange
+      : this._baseRange + this._rangeOffset * (this.rng() - 0.5);
+    this.range = Math.max(0, this.range);
+    this.sqrRange = this.range * this.range;
+  }
+}

--- a/public/js/simulators/physics/bullets/cannon.js
+++ b/public/js/simulators/physics/bullets/cannon.js
@@ -1,0 +1,11 @@
+/**
+ * physics/bullets/cannon.js
+ * CannonBulletUnit — bullet types 1 (CANNON) and 8 (STRAY). The game's
+ * BattleCannonBulletUnit adds no movement override; it is the plain bullet.
+ * This subclass is the anchor for the per-type file pattern the later phases
+ * follow (bomb, torpedo, shrapnel, ...).
+ */
+
+import { BulletUnit } from '../bullet-unit.js';
+
+export class CannonBulletUnit extends BulletUnit {}

--- a/public/js/simulators/physics/constants.js
+++ b/public/js/simulators/physics/constants.js
@@ -1,0 +1,23 @@
+/**
+ * physics/constants.js
+ * BattleConfig physics constants, ported verbatim from the game Lua
+ * (AzurLaneLuaScripts/KR/mod/battle/data/battleconfig.lua and battleformulas.lua).
+ */
+
+// Fixed simulation rate. The game runs every Update at exactly this rate;
+// the simulator's World.step() advances one of these ticks.
+export const VIEW_FPS = 30;                  // battleconfig.lua:5
+export const TICK_SECONDS = 1 / 30;          // battleconfig.lua:7 (calcInterval)
+
+// Bullet speed conversion factor: SECONDs / viewFPS * BulletSpeedConvertConst
+//   = 60 / 30 * 0.1 = 0.2   (battleformulas.lua:9)
+export const BULLET_SPEED_CONVERT = 0.2;
+
+export const GRAVITY = -0.05;                // battleconfig.lua:167
+export const BOMB_DETONATE_HEIGHT = 1.2;     // battleconfig.lua:84
+export const AIRCRAFT_HEIGHT = 10;           // battleconfig.lua:86
+export const ACC_INTERVAL = 1 / 30;          // battlebulletunit.lua:14
+export const BULLET_SPLIT_SHIFT_DELAY = 0.2; // battleconfig.lua:27
+
+// Tracker turn deadzone — cos(10 degrees) (battlebulletunit.lua:15).
+export const TRACKER_ANGLE = Math.cos((10 * Math.PI) / 180);

--- a/public/js/simulators/physics/vec.js
+++ b/public/js/simulators/physics/vec.js
@@ -1,0 +1,23 @@
+/**
+ * physics/vec.js
+ * Minimal planar (2D) vector helpers on plain {x, y} objects. Pure — never
+ * mutates an input. The game works in Vector3 with the Y component filtered
+ * out for movement/range maths; the simulator's horizontal plane is {x, y}.
+ */
+
+/** Component-wise a - b. */
+export function sub(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y };
+}
+
+/** Euclidean length. */
+export function magnitude(v) {
+  return Math.sqrt(v.x * v.x + v.y * v.y);
+}
+
+/** Squared straight-line distance — mirrors the game's Vector3.SqrDistance. */
+export function sqrDistance(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}

--- a/public/js/simulators/physics/world.js
+++ b/public/js/simulators/physics/world.js
@@ -1,0 +1,44 @@
+/**
+ * physics/world.js
+ * World — the fixed-timestep container for the physics simulation. step()
+ * advances every live unit by exactly one 1/30 game-second tick (the game's
+ * fixed Update rate). The view driver calls step() from a real-time
+ * accumulator; the physics itself never reads wall-clock time.
+ */
+
+import { TICK_SECONDS } from './constants.js';
+import { createBulletUnit } from './bullet-registry.js';
+
+export class World {
+  constructor() {
+    this.bullets = [];
+  }
+
+  /**
+   * Create a bullet, resolve its range and initial speed, and add it to the
+   * simulation. Rejects a non-finite spawn position or heading (mirrors the
+   * NaN guard in the current sim.engine.bullet.js createBullet) and returns
+   * null in that case.
+   */
+  spawnBullet(opts) {
+    if (!Number.isFinite(opts.spawnX) ||
+        !Number.isFinite(opts.spawnY) ||
+        !Number.isFinite(opts.yAngle)) {
+      return null;
+    }
+    const unit = createBulletUnit(opts.type, opts);
+    unit.FixRange();
+    unit.InitSpeed();
+    this.bullets.push(unit);
+    return unit;
+  }
+
+  /** Advance the whole simulation by one fixed tick, then cull expired units. */
+  step() {
+    for (const bullet of this.bullets) {
+      bullet.timeElapsed += TICK_SECONDS;
+      bullet.Update();
+    }
+    this.bullets = this.bullets.filter((b) => !b.reachDestFlag);
+  }
+}

--- a/tests/physics/bullet-registry.test.js
+++ b/tests/physics/bullet-registry.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBulletUnit } from '../../public/js/simulators/physics/bullet-registry.js';
+import { CannonBulletUnit } from '../../public/js/simulators/physics/bullets/cannon.js';
+import { BulletUnit } from '../../public/js/simulators/physics/bullet-unit.js';
+
+test('type 1 (CANNON) resolves to a CannonBulletUnit', () => {
+  const u = createBulletUnit(1, { velocity: 10, yAngle: 0 });
+  assert.ok(u instanceof CannonBulletUnit);
+});
+
+test('type 8 (STRAY) also resolves to a CannonBulletUnit', () => {
+  const u = createBulletUnit(8, { velocity: 10, yAngle: 0 });
+  assert.ok(u instanceof CannonBulletUnit);
+});
+
+test('an unregistered type falls back to the BulletUnit base', () => {
+  const u = createBulletUnit(999, { velocity: 10, yAngle: 0 });
+  assert.ok(u instanceof BulletUnit);
+  assert.ok(!(u instanceof CannonBulletUnit));
+});
+
+test('createBulletUnit forwards the options to the constructor', () => {
+  const u = createBulletUnit(1, { velocity: 25, yAngle: 90 });
+  assert.equal(u.velocity, 25);
+  assert.equal(u.yAngle, 90);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BulletUnit } from '../../public/js/simulators/physics/bullet-unit.js';
+
+test('calcSpeed: speed = velocity * 0.2, decomposed along yAngle (0 deg)', () => {
+  const b = new BulletUnit({ velocity: 50, yAngle: 0 });
+  b.calcSpeed();
+  assert.equal(b.speed.x, 10);            // 50 * 0.2 * cos(0)
+  assert.equal(b.speed.y, 0);
+});
+
+test('calcSpeed: yAngle 90 deg fires straight up the y-axis', () => {
+  const b = new BulletUnit({ velocity: 50, yAngle: 90 });
+  b.calcSpeed();
+  assert.ok(Math.abs(b.speed.x) < 1e-9, 'x component is ~0');
+  assert.equal(b.speed.y, 10);            // 50 * 0.2 * sin(90)
+});
+
+test('FixRange: range_offset 0 leaves range exact; sqrRange = range^2', () => {
+  const b = new BulletUnit({ velocity: 10, range: 40, rangeOffset: 0 });
+  b.FixRange();
+  assert.equal(b.range, 40);
+  assert.equal(b.sqrRange, 1600);
+});
+
+test('FixRange: range = base + offset*(rng()-0.5)', () => {
+  // rng() = 0  ->  (0 - 0.5) = -0.5  ->  range = 40 + 20*(-0.5) = 30
+  const b = new BulletUnit({ range: 40, rangeOffset: 20, rng: () => 0 });
+  b.FixRange();
+  assert.equal(b.range, 30);
+  assert.equal(b.sqrRange, 900);
+});
+
+test('FixRange: a negative roll is clamped to 0', () => {
+  // rng() = 0  ->  range = 10 + 100*(-0.5) = -40  ->  clamp to 0
+  const b = new BulletUnit({ range: 10, rangeOffset: 100, rng: () => 0 });
+  b.FixRange();
+  assert.equal(b.range, 0);
+  assert.equal(b.sqrRange, 0);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -38,3 +38,47 @@ test('FixRange: a negative roll is clamped to 0', () => {
   assert.equal(b.range, 0);
   assert.equal(b.sqrRange, 0);
 });
+
+test('InitSpeed: calcSpeed runs and updateSpeed defaults to doNothing', () => {
+  const b = new BulletUnit({ velocity: 50, yAngle: 0 });
+  b.InitSpeed();
+  assert.equal(b.speed.x, 10, 'InitSpeed calls calcSpeed');
+  assert.equal(b.updateSpeed, b.doNothing, 'cannon uses the doNothing path');
+});
+
+test('doNothing: no gravity -> verticalSpeed stays 0', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0, gravity: 0 });
+  b.doNothing();
+  assert.equal(b.verticalSpeed, 0);
+});
+
+test('doNothing: with gravity -> verticalSpeed accrues gravity per tick', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0, gravity: -0.05 });
+  b.doNothing();
+  assert.equal(b.verticalSpeed, -0.05);
+  b.doNothing();
+  assert.equal(b.verticalSpeed, -0.1);
+});
+
+test('Update: a cannon advances position by speed each tick', () => {
+  const b = new BulletUnit({ velocity: 50, yAngle: 0, range: 40, rangeOffset: 0 });
+  b.FixRange();
+  b.InitSpeed();
+  b.Update();
+  assert.equal(b.position.x, 10);
+  assert.equal(b.position.y, 0);
+  b.Update();
+  assert.equal(b.position.x, 20);
+});
+
+test('Update: reachDestFlag trips when squared distance passes sqrRange', () => {
+  // range 25 -> sqrRange 625. speed.x = 10/tick.
+  const b = new BulletUnit({ velocity: 50, yAngle: 0, range: 25, rangeOffset: 0 });
+  b.FixRange();
+  b.InitSpeed();
+  b.Update();                       // x=10, sqrDist 100
+  b.Update();                       // x=20, sqrDist 400 < 625
+  assert.equal(b.reachDestFlag, false);
+  b.Update();                       // x=30, sqrDist 900 > 625
+  assert.equal(b.reachDestFlag, true);
+});

--- a/tests/physics/constants.test.js
+++ b/tests/physics/constants.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as C from '../../public/js/simulators/physics/constants.js';
+
+test('BULLET_SPEED_CONVERT is the game factor 60/30*0.1 = 0.2', () => {
+  assert.equal(C.BULLET_SPEED_CONVERT, 0.2);
+});
+
+test('the fixed tick is 1/30 second at 30 fps', () => {
+  assert.equal(C.VIEW_FPS, 30);
+  assert.equal(C.TICK_SECONDS, 1 / 30);
+  assert.equal(C.ACC_INTERVAL, 1 / 30);
+});
+
+test('gravity and detonation height match BattleConfig', () => {
+  assert.equal(C.GRAVITY, -0.05);
+  assert.equal(C.BOMB_DETONATE_HEIGHT, 1.2);
+  assert.equal(C.AIRCRAFT_HEIGHT, 10);
+});
+
+test('TRACKER_ANGLE is cos(10 degrees)', () => {
+  // Pinned to the literal so the test catches a wrong angle — asserting
+  // against Math.cos(...) would just restate the implementation.
+  assert.equal(C.TRACKER_ANGLE, 0.984807753012208);
+});

--- a/tests/physics/smoke.test.js
+++ b/tests/physics/smoke.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('node:test harness is wired up', () => {
+  assert.equal(1 + 1, 2);
+});

--- a/tests/physics/vec.test.js
+++ b/tests/physics/vec.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sub, magnitude, sqrDistance } from '../../public/js/simulators/physics/vec.js';
+
+test('sub returns the component-wise difference, inputs untouched', () => {
+  const a = { x: 5, y: 8 };
+  const b = { x: 2, y: 3 };
+  assert.deepEqual(sub(a, b), { x: 3, y: 5 });
+  assert.deepEqual(a, { x: 5, y: 8 }, 'sub must not mutate its inputs');
+});
+
+test('magnitude is the Euclidean length', () => {
+  assert.equal(magnitude({ x: 3, y: 4 }), 5);
+});
+
+test('sqrDistance is the squared straight-line distance (no sqrt)', () => {
+  assert.equal(sqrDistance({ x: 0, y: 0 }, { x: 3, y: 4 }), 25);
+});

--- a/tests/physics/world.test.js
+++ b/tests/physics/world.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { World } from '../../public/js/simulators/physics/world.js';
+import { TICK_SECONDS } from '../../public/js/simulators/physics/constants.js';
+
+test('spawnBullet creates a live, range-resolved, speed-initialised unit', () => {
+  const world = new World();
+  const b = world.spawnBullet({
+    type: 1, velocity: 50, yAngle: 0, range: 40, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+  });
+  assert.ok(b, 'spawn succeeds');
+  assert.equal(world.bullets.length, 1);
+  assert.equal(b.sqrRange, 1600, 'FixRange ran');
+  assert.equal(b.speed.x, 10, 'InitSpeed ran');
+});
+
+test('step advances every bullet by one 1/30 s tick', () => {
+  const world = new World();
+  const b = world.spawnBullet({
+    type: 1, velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+  });
+  world.step();
+  assert.equal(b.position.x, 10);
+  assert.equal(b.timeElapsed, TICK_SECONDS);
+});
+
+test('a cannon bullet flies straight and is culled when it passes its range', () => {
+  const world = new World();
+  const b = world.spawnBullet({
+    type: 1, velocity: 50, yAngle: 0, range: 25, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+  });
+  world.step();                         // x=10
+  world.step();                         // x=20, sqrDist 400 < 625
+  assert.equal(world.bullets.length, 1, 'still in flight');
+  world.step();                         // x=30, sqrDist 900 > 625 -> expire
+  assert.equal(b.reachDestFlag, true);
+  assert.equal(world.bullets.length, 0, 'expired bullet is culled');
+});
+
+test('spawnBullet rejects a non-finite spawn coordinate', () => {
+  const world = new World();
+  const b = world.spawnBullet({
+    type: 1, velocity: 10, yAngle: 0, range: 10, spawnX: NaN, spawnY: 0,
+  });
+  assert.equal(b, null);
+  assert.equal(world.bullets.length, 0);
+});


### PR DESCRIPTION
## Summary

- New pure `public/js/simulators/physics/` module — a fixed-timestep `BulletUnit` / `World` engine that mirrors the game's `BattleBulletUnit`, ported faithfully from the `AzurLaneLuaScripts/KR` Lua. This phase covers the cannon (straight-line) path.
- `node:test` harness wired up (`npm test`); 26 new physics unit tests asserting the game's exact formulas — speed conversion `0.2`, range randomization + `max(0,…)` clamp, the fixed 1/30 s tick. 54 tests total, all green; `npm run build` clean.
- The existing `sim.engine.bullet.js` engine is untouched — nothing user-facing changes. This is the foundation for the planned Phases 2–5 (view wiring, projectiles, special bullet types, beam/space-laser weapon layer).

## Test Plan

- [ ] `npm test` → 54 pass, 0 fail
- [ ] `npm run build` → completes clean (the new physics modules are not imported by any page yet)
- [ ] `/simulators/sim-weapon` is visually unchanged (the live engine is not yet swapped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)