### PR TITLE
sim/weapon-physics: Phase 2c — curving movement (doAccelerate / doTrack / doCircle)

### DIFF
--- a/public/js/simulators/physics/acc-table.js
+++ b/public/js/simulators/physics/acc-table.js
@@ -1,0 +1,70 @@
+/**
+ * physics/acc-table.js
+ * parseAccTable — normalise a bullet template's `acceleration` field into the
+ * game's _accTable shape: an ordered list of {t,u,v} acceleration records plus
+ * the optional named tracker / circle / orbit entries.
+ *
+ * The data carries two shapes (verified against bullet_template.json):
+ *   - Array:  [{flip,t,u,v}, ...]                  — pure acceleration records
+ *   - Object: {tracker:{...}} / {circle:{...}}, optionally with numeric keys
+ *             {1:{t,u,v}, 2:{...}, tracker:{...}}   — accel records + a named kind
+ * Both are the JSON serialisation of the Lua's mixed table — an array part for
+ * the doAccelerate records, named keys for tracker / circle / orbit.
+ *
+ * The per-record `flip` flag mirrors a symmetric barrage: when set and the
+ * barrage angle is in (0, 180), v is negated — faithful to the legacy
+ * AccelerationBehavior (spec §E8, verified correct), so a migrated accelerating
+ * bullet matches the legacy one.
+ *
+ * Records are returned as fresh {t,u,v} objects: doAccelerate's
+ * reverseAcceleration flips their u signs in place, and the core never mutates
+ * an input.
+ */
+
+/** True when a `flip` record should have its v negated for this barrage angle. */
+function shouldFlipV(barrageAngle) {
+  if (barrageAngle == null) return false;
+  const normalized = ((barrageAngle % 360) + 360) % 360;
+  return normalized > 0 && normalized < 180;
+}
+
+/**
+ * @param {Array|Object|null} acceleration - the bullet template's raw field.
+ * @param {number|null} [barrageAngle] - barrage angle in degrees, for `flip`.
+ * @returns {{accels: Array<{t,u,v}>, tracker: ?Object, circle: ?Object, orbit: ?Object}}
+ */
+export function parseAccTable(acceleration, barrageAngle = null) {
+  const table = { accels: [], tracker: null, circle: null, orbit: null };
+  if (!acceleration || typeof acceleration !== 'object') return table;
+
+  const rawRecords = [];
+  if (Array.isArray(acceleration)) {
+    for (const entry of acceleration) {
+      if (!entry) continue;
+      if (entry.tracker != null) table.tracker = entry.tracker;
+      else if (entry.circle != null) table.circle = entry.circle;
+      else if (entry.orbit != null) table.orbit = entry.orbit;
+      else rawRecords.push(entry);
+    }
+  } else {
+    for (const key of Object.keys(acceleration)) {
+      const value = acceleration[key];
+      if (key === 'tracker') table.tracker = value;
+      else if (key === 'circle') table.circle = value;
+      else if (key === 'orbit') table.orbit = value;
+      else if (value) rawRecords.push(value);   // numeric-keyed accel record
+    }
+  }
+
+  const flipV = shouldFlipV(barrageAngle);
+  for (const r of rawRecords) {
+    const v = r.v ?? 0;
+    table.accels.push({
+      t: r.t ?? 0,
+      u: r.u ?? 0,
+      v: (r.flip && flipV) ? -v : v,
+    });
+  }
+  table.accels.sort((a, b) => a.t - b.t);
+  return table;
+}

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -111,7 +111,7 @@ export class BulletUnit {
    * Pick the single per-tick movement function. Mirrors InitSpeed
    * (battlebulletunit.lua:738-768). The game's priority chain is
    * HasAcceleration -> doAccelerate, IsTracker -> doTrack, IsCircle -> doCircle,
-   * else doNothing. The tracker / circle branches are wired in following tasks.
+   * else doNothing. The circle branch is wired in a following task.
    */
   InitSpeed() {
     this.calcSpeed();
@@ -124,6 +124,13 @@ export class BulletUnit {
       this._speedNormal = { x: Math.cos(rad), y: Math.sin(rad) };
       this._speedCross = { x: -this._speedNormal.y, y: this._speedNormal.x };
       this.updateSpeed = this.doAccelerate;
+    } else if (this.IsTracker()) {
+      // doTrack: seed the homing parameters (battlebulletunit.lua:751-758).
+      const tracker = this._accTable.tracker;
+      this._trackRange = tracker.range ?? 50;
+      this._trackerAngularRad = (tracker.angular ?? 3) * DEG_TO_RAD;
+      this._trackingTarget = null;
+      this.updateSpeed = this.doTrack;
     } else {
       this.updateSpeed = this.doNothing;
     }

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -9,7 +9,7 @@
  */
 
 import { BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT } from './constants.js';
-import { sqrDistance } from './vec.js';
+import { sqrDistance, magnitude, scale } from './vec.js';
 import { parseAccTable } from './acc-table.js';
 
 const DEG_TO_RAD = Math.PI / 180;
@@ -123,6 +123,69 @@ export class BulletUnit {
     if (this.gravity !== 0) {
       this.verticalSpeed += this.gravity;
     }
+  }
+
+  /**
+   * The acceleration (u, v) active at the current time. Mirrors GetAcceleration
+   * (battlebulletunit.lua:427-442): the latest record whose `t` has elapsed.
+   * The game quantises the lookup to ACC_INTERVAL because it can be called at a
+   * variable rate; the fixed-timestep core advances `timeElapsed` by exactly
+   * one ACC_INTERVAL per tick, so the quantisation is structural and the lookup
+   * is a plain threshold test. `accels` is pre-sorted ascending by `t`.
+   *
+   * `GetSpeedRatio()` multiplies u and v in the game; the simulator has no buff
+   * system so the ratio is always 1 and is omitted (same rationale as calcSpeed).
+   */
+  GetAcceleration() {
+    const accels = this._accTable.accels;
+    // Scan from the LAST record backward, matching the game's loop direction
+    // (battlebulletunit.lua:432-439). accels is sorted ascending by t, so the
+    // first record found with t <= timeElapsed IS the latest active one.
+    // O(1) in the steady state — typically the last or second-to-last record.
+    for (let i = accels.length - 1; i >= 0; i--) {
+      const rec = accels[i];
+      if (rec.t <= this.timeElapsed) return { u: rec.u, v: rec.v };
+    }
+    return { u: 0, v: 0 };
+  }
+
+  /**
+   * Flip every acceleration record's u sign. Mirrors reverseAcceleration
+   * (battlebulletunit.lua:444-448) — the bounce when a negative u would drive
+   * the forward speed below zero. Safe to mutate: parseAccTable returns fresh
+   * record objects.
+   */
+  reverseAcceleration() {
+    for (const rec of this._accTable.accels) rec.u = -rec.u;
+  }
+
+  /**
+   * Movement function for an accelerating bullet. Mirrors doAccelerate
+   * (battlebulletunit.lua:18-38) — the spec §B4 fix. Adds u along the forward
+   * unit vector `_speedNormal` and v along the cross vector `_speedCross` as
+   * velocity-vector components, then re-derives the basis from the new speed.
+   * The turn a given v produces therefore scales with the speed magnitude —
+   * the serpentine weave the legacy fixed-degree turn could not reproduce.
+   */
+  doAccelerate() {
+    const { u, v } = this.GetAcceleration();
+    if (u === 0 && v === 0) return;
+
+    if (u < 0 && this._speedLength + u < 0) {
+      this.reverseAcceleration();
+    }
+
+    this.speed = {
+      x: this.speed.x + this._speedNormal.x * u + this._speedCross.x * v,
+      y: this.speed.y + this._speedNormal.y * u + this._speedCross.y * v,
+    };
+
+    this._speedLength = magnitude(this.speed);
+    if (this._speedLength !== 0) {
+      this._speedNormal = scale(this.speed, 1 / this._speedLength);
+    }
+    // _speedCross = _speedNormal rotated 90deg (game: Cross with Vector3.up).
+    this._speedCross = { x: -this._speedNormal.y, y: this._speedNormal.x };
   }
 
   /**

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -10,6 +10,7 @@
 
 import { BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT } from './constants.js';
 import { sqrDistance } from './vec.js';
+import { parseAccTable } from './acc-table.js';
 
 const DEG_TO_RAD = Math.PI / 180;
 
@@ -37,6 +38,17 @@ export class BulletUnit {
     this.sqrRange = 0;
     this.timeElapsed = 0;
     this.reachDestFlag = false;
+
+    // Movement data. _accTable mirrors the game's mixed _accTable Lua table:
+    // an `accels` list for doAccelerate plus optional tracker / circle / orbit
+    // entries. The base-class InitSpeed reads it to pick the single
+    // updateSpeed function; subclasses that override InitSpeed (e.g.
+    // BombBulletUnit) bypass it.
+    this._accTable = parseAccTable(opts.acceleration, opts.barrageAngle);
+    // Homing target / circle-centre fallback. {x, y} game coords (horizontal plane).
+    this._target = opts.target ?? null;
+    // Live weapon position for the harness-only doOrbit. {x, y} game coords.
+    this._weaponPos = opts.weaponPos ?? null;
   }
 
   /**
@@ -68,12 +80,34 @@ export class BulletUnit {
     this.sqrRange = this.range * this.range;
   }
 
+  // PascalCase mirrors the Lua originals (battlebulletunit.lua:411-423) to
+  // keep the priority chain in InitSpeed readable against the source.
+  /** #_accTable ~= 0 — the array part is non-empty (battlebulletunit.lua:411). */
+  HasAcceleration() {
+    return this._accTable.accels.length > 0;
+  }
+
+  /** _accTable.tracker is set (battlebulletunit.lua:415). */
+  IsTracker() {
+    return this._accTable.tracker != null;
+  }
+
+  /** _accTable.circle is set (battlebulletunit.lua:423). */
+  IsCircle() {
+    return this._accTable.circle != null;
+  }
+
+  /** _accTable.orbit is set (battlebulletunit.lua:419). */
+  IsOrbit() {
+    return this._accTable.orbit != null;
+  }
+
   /**
    * Pick the single per-tick movement function. Mirrors InitSpeed
    * (battlebulletunit.lua:738-768). The game's priority chain is
    * HasAcceleration -> doAccelerate, IsTracker -> doTrack, IsCircle -> doCircle,
-   * else doNothing. Acceleration/tracker/circle are added in Phase 2; for now
-   * every bullet resolves to doNothing.
+   * else doNothing. The accel / tracker / circle branches are wired in the
+   * following tasks; for now every bullet still resolves to doNothing.
    */
   InitSpeed() {
     this.calcSpeed();

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -8,11 +8,16 @@
  * (the game's x/z); `altitude` is the vertical axis (the game's _position.y).
  */
 
-import { BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT } from './constants.js';
-import { sqrDistance, magnitude, scale } from './vec.js';
+import { BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT, TRACKER_ANGLE } from './constants.js';
+import { sqrDistance, magnitude, scale, sub, normalize, dot, rotate } from './vec.js';
 import { parseAccTable } from './acc-table.js';
 
 const DEG_TO_RAD = Math.PI / 180;
+
+// _trackingTarget state machine: null (unacquired) -> the live target (acquired)
+// -> DROPPED (left _trackRange after acquisition; never re-acquired). Mirrors
+// the game's setTrackingTarget(-1) sentinel (battlebulletunit.lua:48,52).
+const DROPPED = Symbol('dropped');
 
 export class BulletUnit {
   constructor(opts = {}) {
@@ -196,6 +201,64 @@ export class BulletUnit {
     }
     // _speedCross = _speedNormal rotated 90deg (game: Cross with Vector3.up).
     this._speedCross = { x: -this._speedNormal.y, y: this._speedNormal.x };
+  }
+
+  /**
+   * Resolve the live tracking target, running the game's acquire / drop
+   * lifecycle (battlebulletunit.lua:41-55). _trackingTarget is null until the
+   * target first enters _trackRange; once bound, leaving _trackRange drops it
+   * permanently (the DROPPED sentinel — the game's setTrackingTarget(-1)).
+   * Returns the target to home on, or null. Caller guarantees this._target.
+   *
+   * Boundary: acquire uses `<= _trackRange`, drop uses `_trackRange <` —
+   * faithful to the Lua. A target sitting exactly on the range edge acquires
+   * and then never drops.
+   */
+  _resolveTrackingTarget() {
+    const distance = magnitude(sub(this._target, this.position));
+    if (this._trackingTarget === null && distance <= this._trackRange) {
+      this._trackingTarget = this._target;
+    }
+    if (this._trackingTarget === null || this._trackingTarget === DROPPED) {
+      return null;
+    }
+    if (this._trackRange < distance) {
+      this._trackingTarget = DROPPED;
+      return null;
+    }
+    return this._trackingTarget;
+  }
+
+  /**
+   * Movement function for a homing bullet. Mirrors doTrack
+   * (battlebulletunit.lua:40-83) — the spec §B5 fix. Holds heading inside the
+   * cos(10deg) deadzone; otherwise turns toward the target, capped at one
+   * angular step, and SNAPS exactly onto the target when within one step
+   * (the game's dot/cross rotation branch — no oscillation or overshoot).
+   */
+  doTrack() {
+    if (!this._target) return;
+    const target = this._resolveTrackingTarget();
+    if (!target) return;
+
+    const toTarget = normalize(sub(target, this.position));
+    const speedDir = normalize(this.speed);
+    const dotValue = dot(speedDir, toTarget);
+    if (dotValue >= TRACKER_ANGLE) return;        // inside the 10deg deadzone
+
+    // Game cross with the z->y mapping: slot4.z*slot3.x - slot4.x*slot3.z.
+    const crossValue = speedDir.y * toTarget.x - speedDir.x * toTarget.y;
+
+    let cos = dotValue;
+    let sin = crossValue;
+    if (dotValue < Math.cos(this._trackerAngularRad)) {
+      // Target more than one step away: turn by the fixed step toward it.
+      cos = Math.cos(this._trackerAngularRad);
+      sin = Math.sin(this._trackerAngularRad) * (crossValue >= 0 ? 1 : -1);
+    }
+    // Within one step (dotValue >= cos(step)): cos/sin stay dot/cross, which
+    // rotates the heading by the exact remaining angle — the snap.
+    this.speed = rotate(this.speed, cos, sin);
   }
 
   /**

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -8,7 +8,9 @@
  * (the game's x/z); `altitude` is the vertical axis (the game's _position.y).
  */
 
-import { BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT, TRACKER_ANGLE } from './constants.js';
+import {
+  BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT, TRACKER_ANGLE, TICK_SECONDS,
+} from './constants.js';
 import { sqrDistance, magnitude, scale, sub, normalize, dot, rotate } from './vec.js';
 import { parseAccTable } from './acc-table.js';
 
@@ -111,7 +113,7 @@ export class BulletUnit {
    * Pick the single per-tick movement function. Mirrors InitSpeed
    * (battlebulletunit.lua:738-768). The game's priority chain is
    * HasAcceleration -> doAccelerate, IsTracker -> doTrack, IsCircle -> doCircle,
-   * else doNothing. The circle branch is wired in a following task.
+   * else doNothing.
    */
   InitSpeed() {
     this.calcSpeed();
@@ -131,6 +133,24 @@ export class BulletUnit {
       this._trackerAngularRad = (tracker.angular ?? 3) * DEG_TO_RAD;
       this._trackingTarget = null;
       this.updateSpeed = this.doTrack;
+    } else if (this.IsCircle()) {
+      // doCircle: seed the orbit state (battlebulletunit.lua:759-764). A data
+      // `center` is {x,y,z}; its planar projection is {x: center.x, y:
+      // center.z} (game z is the core's y). _centripetalSpeed carries the
+      // game's per-tick (1/30 s) scale here so doCircle stays scale-free.
+      const circle = this._accTable.circle;
+      const center = circle.center;
+      this._originPos = center
+        ? { x: center.x, y: center.z ?? 0 }
+        : this._target;
+      this._circleAntiClockwise = !!circle.antiClockWise;
+      this._centripetalSpeed = (circle.centripetalSpeed ?? 0) * TICK_SECONDS;
+      // The Lua sets _convertedVelocity in ResetVelocity / SetTemplateData
+      // before InitSpeed; the core collapses those into construction, and
+      // `velocity` is immutable post-construction, so this seeding is safe.
+      this._convertedVelocity = this.velocity * BULLET_SPEED_CONVERT;
+      this._inverseFlag = 1;
+      this.updateSpeed = this.doCircle;
     } else {
       this.updateSpeed = this.doNothing;
     }

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -269,6 +269,33 @@ export class BulletUnit {
   }
 
   /**
+   * Movement function for a circling bullet. Mirrors doCircle
+   * (battlebulletunit.lua:100-113) — the spec §B7 fix. Rotates the
+   * position-offset vector around the orbit centre and emits speed as the
+   * resulting displacement, which pins an exact radius (the legacy
+   * velocity-rotation drifts). _inverseFlag is the radial in/out oscillation;
+   * _centripetalSpeed already carries the game's per-tick (1/30 s) scaling
+   * applied by InitSpeed. GetSpeedRatio() is 1 and is omitted.
+   */
+  doCircle() {
+    if (!this._originPos) return;
+
+    const offset = sub(this.position, this._originPos);
+    const radius = magnitude(offset);
+    if (radius - this._centripetalSpeed * this._inverseFlag < 0) {
+      this._inverseFlag = -this._inverseFlag;
+    }
+    if (radius <= 1e-5) return;
+
+    const newRadius = radius - this._centripetalSpeed * this._inverseFlag;
+    const angle = (this._convertedVelocity / radius)
+      * (this._circleAntiClockwise ? 1 : -1);
+    const rotated = rotate(offset, Math.cos(angle), Math.sin(angle));
+    const newOffset = scale(rotated, newRadius / radius);
+    this.speed = sub(newOffset, offset);
+  }
+
+  /**
    * Advance the bullet one fixed tick. Mirrors Update (battlebulletunit.lua:
    * 139-157): run the chosen movement function, integrate position by `speed`
    * and altitude by `verticalSpeed`, then test expiry — squared-distance range

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -11,7 +11,7 @@
 import {
   BULLET_SPEED_CONVERT, BOMB_DETONATE_HEIGHT, TRACKER_ANGLE, TICK_SECONDS,
 } from './constants.js';
-import { sqrDistance, magnitude, scale, sub, normalize, dot, rotate } from './vec.js';
+import { sqrDistance, magnitude, scale, sub, normalize, dot, rotate, add } from './vec.js';
 import { parseAccTable } from './acc-table.js';
 
 const DEG_TO_RAD = Math.PI / 180;
@@ -313,6 +313,32 @@ export class BulletUnit {
     const rotated = rotate(offset, Math.cos(angle), Math.sin(angle));
     const newOffset = scale(rotated, newRadius / radius);
     this.speed = sub(newOffset, offset);
+  }
+
+  /**
+   * Movement function for an orbiting bullet. Mirrors doOrbit
+   * (battlebulletunit.lua:85-91), spec §B6 — the two-mode blend: far from the
+   * weapon blend the heading toward it, near (planar distance <= 10) blend it
+   * perpendicular. Emits a unit vector.
+   *
+   * HARNESS-ONLY: InitSpeed never assigns doOrbit — the game's base InitSpeed
+   * has no orbit branch and 0 bullets carry acceleration.orbit (spec Open
+   * item 1). Built for fidelity / possible future subclass use; dead in-page.
+   */
+  doOrbit() {
+    if (!this._weaponPos) return;
+
+    // Reuse one sub for both the direction and the distance — magnitude
+    // ignores sign, so we don't need the reversed (position - weapon) call.
+    const offset = sub(this._weaponPos, this.position);
+    const distance = magnitude(offset);
+    const toWeapon = normalize(offset);
+    const headingDir = normalize(this.speed);
+
+    const blendBase = distance > 10
+      ? toWeapon                                      // far: toward the weapon
+      : { x: -toWeapon.y, y: toWeapon.x };            // near: perpendicular
+    this.speed = normalize(add(blendBase, headingDir));
   }
 
   /**

--- a/public/js/simulators/physics/bullet-unit.js
+++ b/public/js/simulators/physics/bullet-unit.js
@@ -106,12 +106,22 @@ export class BulletUnit {
    * Pick the single per-tick movement function. Mirrors InitSpeed
    * (battlebulletunit.lua:738-768). The game's priority chain is
    * HasAcceleration -> doAccelerate, IsTracker -> doTrack, IsCircle -> doCircle,
-   * else doNothing. The accel / tracker / circle branches are wired in the
-   * following tasks; for now every bullet still resolves to doNothing.
+   * else doNothing. The tracker / circle branches are wired in following tasks.
    */
   InitSpeed() {
     this.calcSpeed();
-    this.updateSpeed = this.doNothing;
+    if (this.HasAcceleration()) {
+      // doAccelerate: seed the forward / cross basis from the firing heading
+      // (battlebulletunit.lua:745-750). _speedCross is _speedNormal rotated
+      // 90deg (the game's Cross with Vector3.up).
+      const rad = this.yAngle * DEG_TO_RAD;
+      this._speedLength = magnitude(this.speed);
+      this._speedNormal = { x: Math.cos(rad), y: Math.sin(rad) };
+      this._speedCross = { x: -this._speedNormal.y, y: this._speedNormal.x };
+      this.updateSpeed = this.doAccelerate;
+    } else {
+      this.updateSpeed = this.doNothing;
+    }
   }
 
   /**

--- a/public/js/simulators/physics/vec.js
+++ b/public/js/simulators/physics/vec.js
@@ -21,3 +21,39 @@ export function sqrDistance(a, b) {
   const dy = a.y - b.y;
   return dx * dx + dy * dy;
 }
+
+/** Unit vector in the direction of `v`; a zero vector returns zero. */
+export function normalize(v) {
+  const len = Math.sqrt(v.x * v.x + v.y * v.y);
+  return len === 0 ? { x: 0, y: 0 } : { x: v.x / len, y: v.y / len };
+}
+
+/** Dot product. */
+export function dot(a, b) {
+  return a.x * b.x + a.y * b.y;
+}
+
+/** Component-wise a + b. */
+export function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y };
+}
+
+/** Scalar multiple of `v`. */
+export function scale(v, k) {
+  return { x: v.x * k, y: v.y * k };
+}
+
+/**
+ * Rotate `v` by the angle whose cosine and sine are given. This is the game's
+ * RotateY (battlebulletunit.lua:93-98) projected onto the core's {x, y} plane
+ * — the game's z axis is the core's y:
+ *   RotateY(v, a) = (v.x*cos + v.z*sin, v.y, v.z*cos - v.x*sin)
+ * Taking cos/sin directly (not an angle) lets doTrack rotate by the angle it
+ * only knows as a dot/cross pair.
+ */
+export function rotate(v, cos, sin) {
+  return {
+    x: v.x * cos + v.y * sin,
+    y: v.y * cos - v.x * sin,
+  };
+}

--- a/public/js/simulators/physics/world.js
+++ b/public/js/simulators/physics/world.js
@@ -19,6 +19,10 @@ export class World {
    * simulation. Rejects a non-finite spawn position, heading or velocity — a
    * NaN velocity yields a bullet whose squared-distance range check never
    * trips, so it would leak — and returns null in that case.
+   *
+   * Curving bullets need no extra spawn path: `opts.acceleration` (plus
+   * `barrageAngle` and `target`) flows straight through to the BulletUnit
+   * constructor, and InitSpeed picks doAccelerate / doTrack / doCircle.
    */
   spawnBullet(opts) {
     if (!Number.isFinite(opts.spawnX) ||

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -15,11 +15,12 @@ import { drainAccumulator } from './physics/accumulator.js';
 import { TICK_SECONDS } from './physics/constants.js';
 
 /**
- * Straight-line bullet types routed through the faithful physics core
- * (physics/). Cannon (1) and Stray (8) use CannonBulletUnit; Torpedo (3) uses
- * TorpedoBulletUnit — all plain straight-line movement. Airdrop bombs route
- * through a separate predicate (_isAirdropBomb). Every other type still runs
- * the legacy BehaviorFactory path until later phases migrate it.
+ * Bullet types routed through the faithful physics core (physics/). Cannon (1)
+ * and Stray (8) use CannonBulletUnit; Torpedo (3) uses TorpedoBulletUnit. All
+ * three support straight and curving movement (doAccelerate / doTrack /
+ * doCircle resolved by InitSpeed — Phase 2c). Airdrop bombs route through a
+ * separate predicate (_isAirdropBomb). Every other type still runs the legacy
+ * BehaviorFactory path until later phases migrate it.
  */
 const MIGRATED_BULLET_TYPES = new Set([1, 8, 3]);
 
@@ -153,11 +154,11 @@ export class BulletEngine {
             return;
         }
 
-        // Route a plain straight-line bullet (cannon / stray / torpedo) to the
-        // faithful physics core; anything with acceleration / gravity / missile
-        // / shrapnel / a transform chain / inherited speed stays on the legacy
-        // path below until later phases migrate it.
-        if (this._isPlainStraightBullet(bulletInfo, options)) {
+        // Route a migrated-type bullet (cannon / stray / torpedo) — straight OR
+        // curving (acceleration / tracker / circle) — to the faithful physics
+        // core; anything with gravity / missile / shrapnel / a transform chain
+        // / inherited speed stays on the legacy path until later phases.
+        if (this._isMigratedMovementBullet(bulletInfo, options)) {
             return this._createWorldBullet(options);
         }
 
@@ -536,15 +537,15 @@ export class BulletEngine {
 
     /**
      * True only for a bullet the physics path provably renders correctly: a
-     * migrated straight-line type (cannon / stray / torpedo) with no
-     * acceleration data, gravity, missile, shrapnel, airdrop, transform chain
-     * or inherited speed. Anything fancier stays on the legacy path — the
-     * conservative test keeps the migration regression-free (a bullet the new
-     * core cannot yet handle is never routed to it).
+     * migrated type (cannon / stray / torpedo) — straight OR curving — with no
+     * gravity, missile, shrapnel, airdrop, transform chain or inherited speed.
+     * Acceleration data is now welcome (Phase 2c): the core's InitSpeed
+     * priority chain resolves it to doAccelerate / doTrack / doCircle. Anything
+     * still excluded has no faithful core path and stays on the legacy path —
+     * the conservative test keeps the migration regression-free.
      */
-    _isPlainStraightBullet(bulletInfo, options) {
+    _isMigratedMovementBullet(bulletInfo, options) {
         return MIGRATED_BULLET_TYPES.has(bulletInfo.type)
-            && this._hasEmptyAcceleration(bulletInfo)
             && !bulletInfo.extra_param?.gravity
             && !bulletInfo.extra_param?.missile
             && !bulletInfo.extra_param?.shrapnel
@@ -586,14 +587,15 @@ export class BulletEngine {
     }
 
     /**
-     * Spawn a straight-line bullet into the physics core and build its DOM
-     * element. Mirrors the legacy createBullet element setup, so a migrated
-     * bullet is visually identical to a legacy one. Receives screen-space
-     * coordinates and converts to game space for the core. Returns the
-     * element, or null if the core rejected the spawn (non-finite input).
+     * Spawn a migrated-type bullet (straight or curving) into the physics core
+     * and build its DOM element. Mirrors the legacy createBullet element setup,
+     * so a migrated bullet is visually identical to a legacy one. Receives
+     * screen-space coordinates and converts to game space for the core.
+     * Returns the element, or null if the core rejected the spawn (non-finite
+     * input).
      */
     _createWorldBullet(options) {
-        const { startX, startY, angle, bulletInfo } = options;
+        const { startX, startY, angle, bulletInfo, barrageAngle, enemyTarget } = options;
         const startGamePos = this.screenToGame(startX, startY);
 
         const unit = this.world.spawnBullet({
@@ -604,6 +606,14 @@ export class BulletEngine {
             rangeOffset: bulletInfo.range_offset || 0,
             spawnX: startGamePos.x,
             spawnY: startGamePos.y,
+            // Curving-movement data (Phase 2c). `acceleration` drives the core's
+            // InitSpeed priority chain; `barrageAngle` resolves the per-record
+            // `flip`; `target` (enemyTarget — already game coords) is the
+            // homing / circle-centre target. A plain bullet has empty
+            // acceleration and ignores all three.
+            acceleration: bulletInfo.acceleration,
+            barrageAngle: barrageAngle,
+            target: enemyTarget,
         });
         if (!unit) return null;
 

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -16,7 +16,7 @@
  * Must stay in sync with public/sw.js CACHE_VERSION. Bumping just one
  * leaves the other cache stale on first visit. See CLAUDE.md "Cache & Data Versioning".
  */
-const DATA_VERSION = '1.10.2';
+const DATA_VERSION = '1.11.0';
 
 /**
  * localStorage keys that participate in Google Drive sync.

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
 // See CLAUDE.md "Cache & Data Versioning" for the bump rules.
 // ============================================
 
-const CACHE_VERSION = '1.10.2';
+const CACHE_VERSION = '1.11.0';
 const STATIC_CACHE = `altoy-static-${CACHE_VERSION}`;
 const DATA_CACHE = `altoy-data-${CACHE_VERSION}`;
 

--- a/tests/physics/acc-table.test.js
+++ b/tests/physics/acc-table.test.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseAccTable } from '../../public/js/simulators/physics/acc-table.js';
+
+test('a null/undefined acceleration yields an empty table', () => {
+  const t = parseAccTable(undefined);
+  assert.deepEqual(t.accels, []);
+  assert.equal(t.tracker, null);
+  assert.equal(t.circle, null);
+  assert.equal(t.orbit, null);
+});
+
+test('an array of records becomes the accels list, sorted by t', () => {
+  const t = parseAccTable([
+    { t: 1, u: 3, v: 4 },
+    { t: 0, u: 1, v: 2 },
+  ]);
+  assert.deepEqual(t.accels, [
+    { t: 0, u: 1, v: 2 },
+    { t: 1, u: 3, v: 4 },
+  ]);
+  assert.equal(t.tracker, null);
+});
+
+test('an object with a tracker key becomes table.tracker, accels empty', () => {
+  const t = parseAccTable({ tracker: { angular: 3, range: 50 } });
+  assert.deepEqual(t.tracker, { angular: 3, range: 50 });
+  assert.deepEqual(t.accels, []);
+});
+
+test('numeric-keyed records plus a tracker key are both captured', () => {
+  // The game _accTable serialised: an array part (numeric keys) + a named key.
+  const t = parseAccTable({
+    1: { t: 0, u: 1, v: 0 },
+    2: { t: 0.5, u: 2, v: 0 },
+    tracker: { angular: 3, range: 50 },
+  });
+  assert.equal(t.accels.length, 2);
+  assert.ok(t.tracker, 'tracker captured alongside the accel records');
+});
+
+test('an object with a circle key becomes table.circle', () => {
+  const t = parseAccTable({ circle: { centripetalSpeed: -1, antiClockWise: true } });
+  assert.deepEqual(t.circle, { centripetalSpeed: -1, antiClockWise: true });
+});
+
+test('flip negates v when the barrage angle is in (0, 180)', () => {
+  const t = parseAccTable([{ t: 0, u: 0, v: 5, flip: true }], 90);
+  assert.equal(t.accels[0].v, -5);
+});
+
+test('flip leaves v alone when the barrage angle is outside (0, 180)', () => {
+  assert.equal(parseAccTable([{ t: 0, u: 0, v: 5, flip: true }], 270).accels[0].v, 5);
+  assert.equal(parseAccTable([{ t: 0, u: 0, v: 5, flip: true }], 0).accels[0].v, 5);
+  assert.equal(parseAccTable([{ t: 0, u: 0, v: 5, flip: true }], null).accels[0].v, 5);
+});
+
+test('flip does nothing for a record without the flag', () => {
+  assert.equal(parseAccTable([{ t: 0, u: 0, v: 5 }], 90).accels[0].v, 5);
+});
+
+test('parsed records are fresh objects — mutating them never touches the input', () => {
+  const input = [{ t: 0, u: 1, v: 0 }];
+  const t = parseAccTable(input);
+  t.accels[0].u = 99;
+  assert.equal(input[0].u, 1, 'the input record is untouched');
+});
+
+test('records with zero-valued fields are preserved and sort by t correctly', () => {
+  // A real first event is often `{t: 0, u: 0, v: <something>}`. This pins that
+  // the t:0 record is not silently dropped and sorts before later records.
+  const t = parseAccTable([{ t: 0, u: 0, v: 3 }, { t: 0.5, u: 0, v: -3 }]);
+  assert.equal(t.accels.length, 2);
+  assert.equal(t.accels[0].t, 0);
+  assert.equal(t.accels[0].u, 0);
+  assert.equal(t.accels[0].v, 3);
+  assert.equal(t.accels[1].t, 0.5);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -143,3 +143,81 @@ test('_accTable: a plain bullet has an empty table — every predicate false', (
   assert.equal(b.IsCircle(), false);
   assert.equal(b.IsOrbit(), false);
 });
+
+test('GetAcceleration: returns the latest record whose t has elapsed', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 1, v: 0 }, { t: 0.5, u: 5, v: 0 }] });
+  b.timeElapsed = 0.1;
+  assert.deepEqual(b.GetAcceleration(), { u: 1, v: 0 });
+  b.timeElapsed = 0.6;
+  assert.deepEqual(b.GetAcceleration(), { u: 5, v: 0 });
+});
+
+test('GetAcceleration: before the first record, returns zero', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 1, u: 9, v: 0 }] });
+  b.timeElapsed = 0.5;
+  assert.deepEqual(b.GetAcceleration(), { u: 0, v: 0 });
+});
+
+test('doAccelerate: a positive u accelerates along the forward vector', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 0.5, v: 0 }] });
+  b.speed = { x: 1, y: 0 };
+  b._speedNormal = { x: 1, y: 0 };
+  b._speedCross = { x: 0, y: 1 };
+  b._speedLength = 1;
+  b.doAccelerate();
+  assert.deepEqual(b.speed, { x: 1.5, y: 0 });
+  assert.equal(b._speedLength, 1.5);
+});
+
+test('doAccelerate: a v adds a cross-vector component and re-derives the basis', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 0, v: 0.5 }] });
+  b.speed = { x: 1, y: 0 };
+  b._speedNormal = { x: 1, y: 0 };
+  b._speedCross = { x: 0, y: 1 };
+  b._speedLength = 1;
+  b.doAccelerate();
+  assert.deepEqual(b.speed, { x: 1, y: 0.5 });          // (1,0) + (0,1)*0.5
+  const len = Math.sqrt(1.25);
+  assert.ok(Math.abs(b._speedLength - len) < 1e-9);
+  assert.ok(Math.abs(b._speedNormal.x - 1 / len) < 1e-9);
+  assert.ok(Math.abs(b._speedNormal.y - 0.5 / len) < 1e-9);
+  assert.ok(Math.abs(b._speedCross.x - (-0.5 / len)) < 1e-9, 'cross = (-normal.y, normal.x)');
+  assert.ok(Math.abs(b._speedCross.y - 1 / len) < 1e-9);
+});
+
+test('doAccelerate: u=0 and v=0 is a no-op', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 0, v: 0 }] });
+  b.speed = { x: 2, y: 0 };
+  b._speedNormal = { x: 1, y: 0 };
+  b._speedCross = { x: 0, y: 1 };
+  b._speedLength = 2;
+  b.doAccelerate();
+  assert.deepEqual(b.speed, { x: 2, y: 0 });
+});
+
+test('doAccelerate: a negative u that would reverse the speed flips every u', () => {
+  // u -2 against forward speed 1: _speedLength + u = -1 < 0 -> reverseAcceleration.
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: -2, v: 0 }] });
+  b.speed = { x: 1, y: 0 };
+  b._speedNormal = { x: 1, y: 0 };
+  b._speedCross = { x: 0, y: 1 };
+  b._speedLength = 1;
+  b.doAccelerate();
+  // reverseAcceleration flips the stored record, but `u` was already
+  // destructured locally before the flip, so this tick still applies -2.
+  assert.deepEqual(b.speed, { x: -1, y: 0 });
+  assert.equal(b._accTable.accels[0].u, 2, 'future records are flipped positive');
+});
+
+test('doAccelerate: u and v applied together compose correctly along forward and cross', () => {
+  // speed (1,0), normal (1,0), cross (0,1); u=0.3, v=0.4
+  // -> speed = (1+1*0.3+0*0.4, 0+0*0.3+1*0.4) = (1.3, 0.4)
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 0.3, v: 0.4 }] });
+  b.speed = { x: 1, y: 0 };
+  b._speedNormal = { x: 1, y: 0 };
+  b._speedCross = { x: 0, y: 1 };
+  b._speedLength = 1;
+  b.doAccelerate();
+  assert.ok(Math.abs(b.speed.x - 1.3) < 1e-9);
+  assert.ok(Math.abs(b.speed.y - 0.4) < 1e-9);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -260,3 +260,68 @@ test('Update: an accelerating bullet curves off the firing axis', () => {
   b.Update();
   assert.ok(b.position.y > 0, 'the bullet has curved off the x-axis');
 });
+
+// doTrack test harness: seed the fields InitSpeed's tracker branch will set
+// (Task 7), then drive doTrack directly.
+function trackerBullet({ speed, target, trackRange = 100, angularDeg = 30 }) {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.speed = { ...speed };
+  b.position = { x: 0, y: 0 };
+  b._target = target;
+  b._trackRange = trackRange;
+  b._trackerAngularRad = angularDeg * (Math.PI / 180);
+  b._trackingTarget = null;
+  return b;
+}
+
+test('doTrack: turns toward a target more than one angular step away', () => {
+  // Heading +x, target at 45deg, angular step 30deg -> turn 30deg toward +y.
+  const b = trackerBullet({ speed: { x: 2, y: 0 }, target: { x: 10, y: 10 }, angularDeg: 30 });
+  b.doTrack();
+  // rotate((2,0), cos30, -sin30): cross is negative so s = -sin30.
+  assert.ok(Math.abs(b.speed.x - 2 * Math.cos(Math.PI / 6)) < 1e-9);
+  assert.ok(Math.abs(b.speed.y - 2 * Math.sin(Math.PI / 6)) < 1e-9);
+  assert.ok(Math.abs(Math.hypot(b.speed.x, b.speed.y) - 2) < 1e-9, 'speed preserved');
+});
+
+test('doTrack: snaps onto the target when within one angular step', () => {
+  // Heading +x, target at 45deg, angular step 90deg -> snap straight to 45deg.
+  const b = trackerBullet({ speed: { x: 2, y: 0 }, target: { x: 10, y: 10 }, angularDeg: 90 });
+  b.doTrack();
+  assert.ok(Math.abs(b.speed.x - Math.SQRT2) < 1e-9, 'heading lands on the target');
+  assert.ok(Math.abs(b.speed.y - Math.SQRT2) < 1e-9);
+});
+
+test('doTrack: no turn inside the 10deg deadzone', () => {
+  // Target ~2.86deg off the heading -> within cos(10deg) -> no turn.
+  const b = trackerBullet({ speed: { x: 2, y: 0 }, target: { x: 100, y: 5 } });
+  b.doTrack();
+  assert.deepEqual(b.speed, { x: 2, y: 0 });
+});
+
+test('doTrack: a target beyond trackRange is never acquired', () => {
+  const b = trackerBullet({
+    speed: { x: 2, y: 0 }, target: { x: 20, y: 20 }, trackRange: 5,
+  });
+  b.doTrack();
+  assert.deepEqual(b.speed, { x: 2, y: 0 }, 'unacquired -> no turn');
+});
+
+test('doTrack: a target that leaves trackRange is dropped permanently', () => {
+  const b = trackerBullet({ speed: { x: 2, y: 0 }, target: { x: 5, y: 5 }, trackRange: 10 });
+  b.doTrack();                                  // acquired (dist ~7.07 < 10), turns
+  const turned = { ...b.speed };
+  b._target = { x: 80, y: 80 };                 // dist ~113 > 10 -> dropped
+  b.doTrack();
+  b._target = { x: 3, y: 3 };                   // back in range...
+  const before = { ...b.speed };
+  b.doTrack();
+  assert.deepEqual(b.speed, before, 'a dropped target is never re-acquired');
+  assert.notDeepEqual(turned, { x: 2, y: 0 });  // sanity: the first call did turn
+});
+
+test('doTrack: with no target at all, it is a no-op', () => {
+  const b = trackerBullet({ speed: { x: 2, y: 0 }, target: null });
+  b.doTrack();
+  assert.deepEqual(b.speed, { x: 2, y: 0 });
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -98,3 +98,48 @@ test('Update: a gravity bullet detonates at the bomb-detonation height', () => {
   b.Update();                 // altitude -1.0
   assert.equal(b.reachDestFlag, true, 'detonates at/below 1.2');
 });
+
+test('_accTable: an array of records makes HasAcceleration true', () => {
+  const b = new BulletUnit({ acceleration: [{ t: 0, u: 1, v: 0 }] });
+  assert.equal(b.HasAcceleration(), true);
+  assert.equal(b.IsTracker(), false);
+  assert.equal(b.IsCircle(), false);
+  assert.equal(b.IsOrbit(), false);
+});
+
+test('_accTable: a tracker object makes IsTracker true, HasAcceleration false', () => {
+  const b = new BulletUnit({ acceleration: { tracker: { angular: 3, range: 50 } } });
+  assert.equal(b.IsTracker(), true);
+  assert.equal(b.HasAcceleration(), false);
+});
+
+test('_accTable: a circle object makes IsCircle true', () => {
+  const b = new BulletUnit({ acceleration: { circle: { centripetalSpeed: -1 } } });
+  assert.equal(b.IsCircle(), true);
+});
+
+test('_accTable: an orbit object makes IsOrbit true', () => {
+  const b = new BulletUnit({ acceleration: { orbit: { radius: 10 } } });
+  assert.equal(b.IsOrbit(), true);
+  assert.equal(b.HasAcceleration(), false);
+  assert.equal(b.IsTracker(), false);
+  assert.equal(b.IsCircle(), false);
+});
+
+test('_accTable: accel records AND a tracker — both predicates true', () => {
+  // The game priority chain (InitSpeed) resolves this to doAccelerate; the
+  // predicates themselves just report what data is present.
+  const b = new BulletUnit({
+    acceleration: { 1: { t: 0, u: 1, v: 0 }, tracker: { angular: 3, range: 50 } },
+  });
+  assert.equal(b.HasAcceleration(), true);
+  assert.equal(b.IsTracker(), true);
+});
+
+test('_accTable: a plain bullet has an empty table — every predicate false', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  assert.equal(b.HasAcceleration(), false);
+  assert.equal(b.IsTracker(), false);
+  assert.equal(b.IsCircle(), false);
+  assert.equal(b.IsOrbit(), false);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -221,3 +221,42 @@ test('doAccelerate: u and v applied together compose correctly along forward and
   assert.ok(Math.abs(b.speed.x - 1.3) < 1e-9);
   assert.ok(Math.abs(b.speed.y - 0.4) < 1e-9);
 });
+
+test('InitSpeed: an accelerating bullet resolves to doAccelerate', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0, acceleration: [{ t: 0, u: 1, v: 0 }] });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doAccelerate);
+  assert.ok(Math.abs(b._speedNormal.x - 1) < 1e-9);
+  assert.ok(Math.abs(b._speedNormal.y - 0) < 1e-9);
+  assert.ok(Math.abs(b._speedCross.x - 0) < 1e-9);
+  assert.ok(Math.abs(b._speedCross.y - 1) < 1e-9);
+  assert.equal(b._speedLength, 2, 'velocity 10 * 0.2');
+});
+
+test('InitSpeed: the accel basis follows yAngle 90 deg', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 90, acceleration: [{ t: 0, u: 1, v: 0 }] });
+  b.InitSpeed();
+  assert.ok(Math.abs(b._speedNormal.x - 0) < 1e-9);
+  assert.ok(Math.abs(b._speedNormal.y - 1) < 1e-9);
+  assert.ok(Math.abs(b._speedCross.x - (-1)) < 1e-9);
+  assert.ok(Math.abs(b._speedCross.y - 0) < 1e-9);
+});
+
+test('InitSpeed: a plain bullet still resolves to doNothing', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doNothing);
+});
+
+test('Update: an accelerating bullet curves off the firing axis', () => {
+  // Fired along +x with a constant cross-acceleration v=0.5 -> it curves +y.
+  const b = new BulletUnit({
+    velocity: 5, yAngle: 0, range: 500, rangeOffset: 0,
+    acceleration: [{ t: 0, u: 0, v: 0.5 }],
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.Update();
+  b.Update();
+  assert.ok(b.position.y > 0, 'the bullet has curved off the x-axis');
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -352,3 +352,60 @@ test('InitSpeed: a tracker with no fields falls back to defaults', () => {
   assert.equal(b._trackRange, 50);
   assert.ok(Math.abs(b._trackerAngularRad - 3 * Math.PI / 180) < 1e-12);
 });
+
+// doCircle test harness: seed the fields InitSpeed's circle branch will set.
+function circleBullet({ position, originPos, convertedVelocity, centripetalSpeed = 0,
+                        antiClockwise = false, inverseFlag = 1 }) {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.position = { ...position };
+  b._originPos = originPos;
+  b._convertedVelocity = convertedVelocity;
+  b._centripetalSpeed = centripetalSpeed;
+  b._circleAntiClockwise = antiClockwise;
+  b._inverseFlag = inverseFlag;
+  return b;
+}
+
+test('doCircle: with no centripetal pull, the radius is pinned exactly', () => {
+  const b = circleBullet({
+    position: { x: 10, y: 0 }, originPos: { x: 0, y: 0 }, convertedVelocity: 2,
+  });
+  b.doCircle();
+  // speed is a displacement; the next position must stay on the radius-10 circle.
+  const next = { x: b.position.x + b.speed.x, y: b.position.y + b.speed.y };
+  const newRadius = Math.hypot(next.x, next.y);
+  assert.ok(Math.abs(newRadius - 10) < 1e-9, `radius pinned at 10, got ${newRadius}`);
+});
+
+test('doCircle: an inward spiral shrinks the radius by centripetalSpeed', () => {
+  // radius 10, centripetal 2, flag 1: 10 - 2*1 = 8 (>= 0, flag stays +1).
+  // newRadius = 8 -> next position lands on the radius-8 circle.
+  const b = circleBullet({
+    position: { x: 10, y: 0 }, originPos: { x: 0, y: 0 },
+    convertedVelocity: 2, centripetalSpeed: 2, inverseFlag: 1,
+  });
+  b.doCircle();
+  const next = { x: b.position.x + b.speed.x, y: b.position.y + b.speed.y };
+  const newRadius = Math.hypot(next.x, next.y);
+  assert.ok(Math.abs(newRadius - 8) < 1e-9, `expected radius 8, got ${newRadius}`);
+  assert.equal(b._inverseFlag, 1, 'flag does not flip when radius - centripetal >= 0');
+});
+
+test('doCircle: the inverse flag flips when the radius would go negative', () => {
+  // radius 10, centripetal 15, flag 1: 10 - 15*1 = -5 < 0 -> flag flips to -1.
+  const b = circleBullet({
+    position: { x: 10, y: 0 }, originPos: { x: 0, y: 0 }, convertedVelocity: 2,
+    centripetalSpeed: 15, inverseFlag: 1,
+  });
+  b.doCircle();
+  assert.equal(b._inverseFlag, -1);
+});
+
+test('doCircle: with no origin, it is a no-op', () => {
+  const b = circleBullet({
+    position: { x: 10, y: 0 }, originPos: null, convertedVelocity: 2,
+  });
+  b.speed = { x: 7, y: 7 };
+  b.doCircle();
+  assert.deepEqual(b.speed, { x: 7, y: 7 });
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -325,3 +325,30 @@ test('doTrack: with no target at all, it is a no-op', () => {
   b.doTrack();
   assert.deepEqual(b.speed, { x: 2, y: 0 });
 });
+
+test('InitSpeed: a tracker bullet resolves to doTrack', () => {
+  const b = new BulletUnit({
+    velocity: 10, yAngle: 0, acceleration: { tracker: { angular: 3, range: 50 } },
+  });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doTrack);
+  assert.equal(b._trackRange, 50);
+  assert.ok(Math.abs(b._trackerAngularRad - 3 * Math.PI / 180) < 1e-12);
+  assert.equal(b._trackingTarget, null);
+});
+
+test('InitSpeed: accel records outrank a tracker key (game priority)', () => {
+  const b = new BulletUnit({
+    velocity: 10, yAngle: 0,
+    acceleration: { 1: { t: 0, u: 1, v: 0 }, tracker: { angular: 3, range: 50 } },
+  });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doAccelerate, 'HasAcceleration wins over IsTracker');
+});
+
+test('InitSpeed: a tracker with no fields falls back to defaults', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0, acceleration: { tracker: {} } });
+  b.InitSpeed();
+  assert.equal(b._trackRange, 50);
+  assert.ok(Math.abs(b._trackerAngularRad - 3 * Math.PI / 180) < 1e-12);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -409,3 +409,33 @@ test('doCircle: with no origin, it is a no-op', () => {
   b.doCircle();
   assert.deepEqual(b.speed, { x: 7, y: 7 });
 });
+
+test('InitSpeed: a circle bullet resolves to doCircle', () => {
+  const b = new BulletUnit({
+    velocity: 10, yAngle: 0,
+    acceleration: { circle: { centripetalSpeed: -1, antiClockWise: true,
+                              center: { x: 5, y: 0, z: 7 } } },
+  });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doCircle);
+  assert.deepEqual(b._originPos, { x: 5, y: 7 }, 'center {x,z} -> planar {x,y}');
+  assert.equal(b._circleAntiClockwise, true);
+  assert.ok(Math.abs(b._centripetalSpeed - (-1 / 30)) < 1e-12, 'scaled by 1/30');
+  assert.equal(b._convertedVelocity, 2, 'velocity 10 * 0.2');
+  assert.equal(b._inverseFlag, 1);
+});
+
+test('InitSpeed: a circle with no center falls back to the bullet target', () => {
+  const b = new BulletUnit({
+    velocity: 10, yAngle: 0, target: { x: 9, y: 9 },
+    acceleration: { circle: { centripetalSpeed: 0 } },
+  });
+  b.InitSpeed();
+  assert.deepEqual(b._originPos, { x: 9, y: 9 });
+});
+
+test('InitSpeed: a plain bullet still resolves to doNothing (circle branch added)', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doNothing);
+});

--- a/tests/physics/bullet-unit.test.js
+++ b/tests/physics/bullet-unit.test.js
@@ -439,3 +439,48 @@ test('InitSpeed: a plain bullet still resolves to doNothing (circle branch added
   b.InitSpeed();
   assert.equal(b.updateSpeed, b.doNothing);
 });
+
+test('doOrbit: far from the weapon, blends the heading toward it', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.position = { x: 0, y: 0 };
+  b.speed = { x: 1, y: 0 };
+  b._weaponPos = { x: 100, y: 0 };          // distance 100 > 10 -> far mode
+  b.doOrbit();
+  // toward (1,0) + heading (1,0), normalised -> (1,0); unit vector.
+  assert.ok(Math.abs(b.speed.x - 1) < 1e-9);
+  assert.ok(Math.abs(b.speed.y - 0) < 1e-9);
+});
+
+test('doOrbit: near the weapon, blends the heading perpendicular', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.position = { x: 0, y: 0 };
+  b.speed = { x: 1, y: 0 };
+  b._weaponPos = { x: 5, y: 0 };            // distance 5 <= 10 -> near mode
+  b.doOrbit();
+  // perp of toward(1,0) is (0,1); + heading (1,0) -> normalise (1,1).
+  assert.ok(Math.abs(b.speed.x - Math.SQRT1_2) < 1e-9);
+  assert.ok(Math.abs(b.speed.y - Math.SQRT1_2) < 1e-9);
+});
+
+test('doOrbit: always emits a unit vector', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.position = { x: 0, y: 0 };
+  b.speed = { x: 4, y: 0 };
+  b._weaponPos = { x: 5, y: 0 };
+  b.doOrbit();
+  assert.ok(Math.abs(Math.hypot(b.speed.x, b.speed.y) - 1) < 1e-9);
+});
+
+test('doOrbit: with no weapon position, it is a no-op', () => {
+  const b = new BulletUnit({ velocity: 10, yAngle: 0 });
+  b.speed = { x: 3, y: 0 };
+  b.doOrbit();
+  assert.deepEqual(b.speed, { x: 3, y: 0 });
+});
+
+test('InitSpeed: an orbit bullet resolves to doNothing — doOrbit is never wired', () => {
+  // Spec Open item 1: base InitSpeed has no orbit branch; 0 bullets carry it.
+  const b = new BulletUnit({ velocity: 10, yAngle: 0, acceleration: { orbit: {} } });
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doNothing);
+});

--- a/tests/physics/vec.test.js
+++ b/tests/physics/vec.test.js
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { sub, magnitude, sqrDistance } from '../../public/js/simulators/physics/vec.js';
+import {
+  sub, magnitude, sqrDistance, normalize, dot, add, scale, rotate,
+} from '../../public/js/simulators/physics/vec.js';
 
 test('sub returns the component-wise difference, inputs untouched', () => {
   const a = { x: 5, y: 8 };
@@ -15,4 +17,50 @@ test('magnitude is the Euclidean length', () => {
 
 test('sqrDistance is the squared straight-line distance (no sqrt)', () => {
   assert.equal(sqrDistance({ x: 0, y: 0 }, { x: 3, y: 4 }), 25);
+});
+
+test('normalize: scales a vector to unit length', () => {
+  assert.deepEqual(normalize({ x: 3, y: 4 }), { x: 0.6, y: 0.8 });
+});
+
+test('normalize: a zero vector returns zero (no division by zero)', () => {
+  assert.deepEqual(normalize({ x: 0, y: 0 }), { x: 0, y: 0 });
+});
+
+test('dot: sum of products of corresponding components', () => {
+  assert.equal(dot({ x: 1, y: 2 }, { x: 3, y: 4 }), 11);
+});
+
+test('add: component-wise sum', () => {
+  assert.deepEqual(add({ x: 1, y: -2 }, { x: 3, y: 5 }), { x: 4, y: 3 });
+});
+
+test('scale: multiplies both components', () => {
+  assert.deepEqual(scale({ x: 2, y: -3 }, 2), { x: 4, y: -6 });
+  assert.deepEqual(scale({ x: 2, y: 3 }, 0), { x: 0, y: 0 });
+  assert.deepEqual(scale({ x: 2, y: 3 }, -1), { x: -2, y: -3 });
+});
+
+test('rotate: a +90 deg rotation (cos 0, sin 1) maps +x to -y', () => {
+  assert.deepEqual(rotate({ x: 1, y: 0 }, 0, 1), { x: 0, y: -1 });
+  assert.deepEqual(rotate({ x: 0, y: 1 }, 0, 1), { x: 1, y: 0 });
+});
+
+test('rotate: preserves magnitude for a unit (cos, sin) pair', () => {
+  const r = rotate({ x: 2, y: 0 }, Math.cos(0.4), Math.sin(0.4));
+  assert.ok(Math.abs(Math.hypot(r.x, r.y) - 2) < 1e-9, 'magnitude unchanged');
+});
+
+test('the new helpers never mutate their inputs', () => {
+  const v = { x: 3, y: 4 };
+  normalize(v);
+  assert.deepEqual(v, { x: 3, y: 4 }, 'normalize must not mutate its input');
+  scale(v, 5);
+  assert.deepEqual(v, { x: 3, y: 4 }, 'scale must not mutate its input');
+  rotate(v, 0, 1);
+  assert.deepEqual(v, { x: 3, y: 4 }, 'rotate must not mutate its input');
+  add(v, v);
+  assert.deepEqual(v, { x: 3, y: 4 }, 'add must not mutate either input (aliased)');
+  dot(v, v);
+  assert.deepEqual(v, { x: 3, y: 4 }, 'dot must not mutate either input (aliased)');
 });

--- a/tests/physics/world.test.js
+++ b/tests/physics/world.test.js
@@ -139,3 +139,54 @@ test('a velocity-0 bomb free-falls under gravity and detonates', () => {
   assert.equal(world.bullets.length, 0, 'velocity-0 bomb detonated');
   assert.ok(steps > 1, 'it took multiple ticks to fall (not instant)');
 });
+
+test('a serpentine accelerating bullet weaves off its firing axis and back', () => {
+  // Type-1 cannon fired along +x with an oscillating cross-acceleration — the
+  // shape of Alsace's bullets 160907/160908. v=+0.27 for the first 0.5 s curves
+  // it +y; v=-0.27 then curves it back. (Reachability audit: doAccelerate is
+  // exercised in-page by 514 reached bullets.)
+  const world = new World();
+  world.spawnBullet({
+    type: 1, velocity: 8, yAngle: 0, range: 500, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    acceleration: [{ t: 0, u: 0, v: 0.27 }, { t: 0.5, u: 0, v: -0.27 }],
+  });
+  const bullet = world.bullets[0];
+
+  for (let i = 0; i < 14; i++) world.step();      // v=+0.27 phase
+  assert.ok(bullet.position.y > 0, 'weaved off the +x axis');
+  assert.ok(bullet.speed.y > 0, 'still curving up at the end of the + phase');
+
+  for (let i = 0; i < 20; i++) world.step();      // into the v=-0.27 phase
+  assert.ok(bullet.speed.y < 0, 'the - phase has fully reversed the weave');
+});
+
+test('a homing tracker bullet curves toward its target', () => {
+  // Type-1 cannon fired along +x at a target up and to the right.
+  const world = new World();
+  world.spawnBullet({
+    type: 1, velocity: 10, yAngle: 0, range: 300, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    acceleration: { tracker: { angular: 90, range: 200 } },
+    target: { x: 40, y: 40 },
+  });
+  const bullet = world.bullets[0];
+
+  for (let i = 0; i < 6; i++) world.step();
+  assert.ok(bullet.position.y > 0, 'curved off the +x axis toward the target');
+  assert.ok(bullet.speed.y > 0, 'heading now has an upward component');
+});
+
+test('a plain cannon is unaffected by the curving machinery', () => {
+  // Regression: no acceleration data -> doNothing -> dead-straight, as Phase 2.
+  const world = new World();
+  world.spawnBullet({
+    type: 1, velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+  });
+  const bullet = world.bullets[0];
+  world.step();
+  world.step();
+  assert.equal(bullet.position.y, 0, 'a plain cannon flies dead straight');
+  assert.equal(bullet.position.x, 20, 'velocity 50 * 0.2 = 10/tick, 2 ticks');
+});


### PR DESCRIPTION
## Summary

Ports the game's three curving movement functions onto the faithful physics core and wires them through `InitSpeed`'s priority chain:

- **`doAccelerate`** (spec §B4) — adds `u` along `_speedNormal` and `v` along `_speedCross` as velocity-vector components, then re-derives the basis from the new speed. The fix for the headline "Alsace flies diagonally off-screen" bug (legacy treated `v` as fixed-degree turn).
- **`doTrack`** (§B5) — cos(10°) deadzone, fixed-step turn toward target, **snap-to-target when within one step** (the game's `dot/cross` rotation branch — no oscillation), permanent-drop lifecycle once a target leaves `_trackRange`.
- **`doCircle`** (§B7) — rotates the position-offset vector around the centre and emits `speed` as the displacement, **pinning an exact radius** (the legacy velocity-rotation drifts).
- **`doOrbit`** (§B6) — built and test-verified, but `InitSpeed` deliberately never wires it. Closes Open item 1: the game's base `InitSpeed` has no orbit branch and 0 bullets carry `acceleration.orbit`.

The view-driver dispatch predicate (`_isMigratedMovementBullet`, renamed from `_isPlainStraightBullet`) drops the empty-acceleration gate, so cannon-family (1 / 8) and torpedo (3) bullets with curving data now route to the core. The legacy `BehaviorFactory` path stays intact for anything still excluded (gravity, missile, shrapnel, airdrop, transform chain, inherited speed). Strangler-fig migration; the legacy path is deleted only in spec Phase 5.

Cache / data version bumped 1.10.2 → 1.11.0 (MINOR — new behavioural capability).

## What landed

- **New** `public/js/simulators/physics/acc-table.js` — `parseAccTable` normalises both array and object acceleration shapes into one `{ accels, tracker, circle, orbit }` structure; applies the `flip` mirror (faithful to the legacy `AccelerationBehavior`).
- `physics/vec.js` gains `normalize`, `dot`, `add`, `scale`, `rotate(v, cos, sin)`.
- `BulletUnit` gains `_accTable`, four `Has*` / `Is*` predicates, the four movement functions, `GetAcceleration` / `reverseAcceleration`, the `_resolveTrackingTarget` acquire/drop state machine (`DROPPED` Symbol sentinel), and the priority-chain wiring in `InitSpeed`.
- View driver: dispatch predicate relaxed; `_createWorldBullet` passes `acceleration` / `barrageAngle` / `target` to `world.spawnBullet`.
- 59 new tests (83 → 142 in `tests/physics/`). Two `world.test.js` integration tests prove the Alsace-shaped serpentine weave and a homing curve compose through `World.step()`.

## Test Plan

- [x] `npm test` — **142/142** passing, 0 skipped
- [x] `npm run check:versions` — both at `1.11.0`
- [x] `npm run build:no-minify` — clean
- [x] Manual visual verification on `/simulators/sim-weapon`: accelerating bullets (BIG SEVEN - 사쿠라, 사르데냐의 위압, …) trace visible curves; homing bullets (AntiTorpedoField, 운명의 총탄, …) bend toward the enemy with a stable deadzone; plain cannon / torpedo / airdrop bomb unchanged; legacy `BehaviorFactory` path untouched
- [x] Per-task two-stage review (spec compliance + code quality) — see `dev/active/2026-05-19-weapon-physics-rework-phase2c-plan.md`

## Known follow-up (separate from this PR)

`main`'s `8518cdd` "data / data pipeline update" dropped ~93 skills (including Alsace `150020` and Musashi) that were present after `afbd8e8`. Phase 2c is validated against the remaining **217 accel + 42 tracker** reached skills. Restoring the dropped skills is a separate data-pipeline task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)