### PR TITLE
Phase 3a: Shrapnel state lattice + type-9 effect lifetime

### DIFF
--- a/public/js/simulators/physics/bullet-registry.js
+++ b/public/js/simulators/physics/bullet-registry.js
@@ -9,6 +9,7 @@ import { BulletUnit } from './bullet-unit.js';
 import { CannonBulletUnit } from './bullets/cannon.js';
 import { TorpedoBulletUnit } from './bullets/torpedo.js';
 import { BombBulletUnit } from './bullets/bomb.js';
+import { EffectBulletUnit } from './bullets/effect.js';
 
 const BULLET_CLASSES = {
   1: CannonBulletUnit,   // CANNON
@@ -16,6 +17,7 @@ const BULLET_CLASSES = {
   3: TorpedoBulletUnit,  // TORPEDO
   2: BombBulletUnit,     // BOMB
   16: BombBulletUnit,    // bomb-family (airdrop-dispatched only if flagged; none in current data)
+  9: EffectBulletUnit,   // EFFECT — lifetime cap by hit_type.time
 };
 
 /** Construct the BulletUnit subclass for `type`, forwarding `opts`. */

--- a/public/js/simulators/physics/bullet-registry.js
+++ b/public/js/simulators/physics/bullet-registry.js
@@ -10,14 +10,16 @@ import { CannonBulletUnit } from './bullets/cannon.js';
 import { TorpedoBulletUnit } from './bullets/torpedo.js';
 import { BombBulletUnit } from './bullets/bomb.js';
 import { EffectBulletUnit } from './bullets/effect.js';
+import { ShrapnelBulletUnit } from './bullets/shrapnel.js';
 
 const BULLET_CLASSES = {
-  1: CannonBulletUnit,   // CANNON
-  8: CannonBulletUnit,   // STRAY — same straight-line movement
-  3: TorpedoBulletUnit,  // TORPEDO
-  2: BombBulletUnit,     // BOMB
-  16: BombBulletUnit,    // bomb-family (airdrop-dispatched only if flagged; none in current data)
-  9: EffectBulletUnit,   // EFFECT — lifetime cap by hit_type.time
+  1: CannonBulletUnit,      // CANNON
+  8: CannonBulletUnit,      // STRAY — same straight-line movement
+  3: TorpedoBulletUnit,     // TORPEDO
+  2: BombBulletUnit,        // BOMB
+  16: BombBulletUnit,       // bomb-family (airdrop-dispatched only if flagged; none in current data)
+  9: EffectBulletUnit,      // EFFECT — lifetime cap by hit_type.time
+  5: ShrapnelBulletUnit,    // SHRAPNEL — fan-fired child bullets from a parent burst
 };
 
 /** Construct the BulletUnit subclass for `type`, forwarding `opts`. */

--- a/public/js/simulators/physics/bullets/effect.js
+++ b/public/js/simulators/physics/bullets/effect.js
@@ -1,0 +1,44 @@
+/**
+ * physics/bullets/effect.js
+ * EffectBulletUnit — bullet type 9. Mirrors BattleEffectBulletUnit
+ * (battleeffectbulletunit.lua). Thin: inherits all movement from BulletUnit
+ * and adds a lifetime cap from hit_type.time.
+ *
+ * The lifetime fix closes spec bug #4 ("lingering red-dot effect, never
+ * removed"): the legacy view path has no type-9 cleanup, so the bullet
+ * element survives forever. Here, reachDestFlag flips when timeElapsed
+ * crosses the cap, the world culls the unit, and the view driver removes
+ * the DOM node via its standard expiry path.
+ */
+
+import { BulletUnit } from '../bullet-unit.js';
+
+export class EffectBulletUnit extends BulletUnit {
+  constructor(opts = {}) {
+    super(opts);
+    // hit_type.time = lifetime cap, in addition to range expiry.
+    // null / undefined / <= 0 -> only range expiry applies. The "<= 0" case
+    // is the data's "infinite lifetime" sentinel (bullet 19010 carries
+    // `hit_type.time: -1`; 17 templates total, 1 reached in the current
+    // skill set) — without this guard a -1 cap would expire on tick 1.
+    this._lifetimeCap = (opts.hitTypeTime != null && opts.hitTypeTime > 0)
+      ? opts.hitTypeTime
+      : null;
+    this._explodePos = null;
+  }
+
+  Update() {
+    super.Update();                                   // movement + IsOutRange
+    if (this._lifetimeCap != null && this.timeElapsed >= this._lifetimeCap) {
+      this.reachDestFlag = true;
+    }
+  }
+
+  /**
+   * Mirrors BattleEffectBulletUnit.SetExplodePosition (battleeffectbulletunit.lua:71-73).
+   * Stored but not used by movement — this sim has no buff-area model.
+   */
+  SetExplodePosition(pos) {
+    this._explodePos = pos;
+  }
+}

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -36,16 +36,102 @@ export class ShrapnelBulletUnit extends BulletUnit {
     this._extraParam = opts.extraParam ?? {};
     this._explodePos = opts.explodePos ?? null;
     this._bulletTemplates = opts.bulletTemplates ?? {};
+    this._barrages = opts.barrages ?? {};
     this._currentState = STATE.NORMAL;
     this._spinStartTime = -1;
     this._pendingEmits = [];
 
-    // Emission state is initialised by _setupEmissions() — implemented in
-    // Task 9 (trailing) and Task 10 (split). For Task 7 these fields are
-    // declared so the rest of the class can refer to them safely.
     this._trailing = [];
     this._splitGroups = [];
     this._splitEntryTime = -1;
+
+    this._setupEmissions();
+  }
+
+  /**
+   * Walk extra_param.shrapnel[] (a numeric-keyed object in data, plus a
+   * conventional FXID string field that's not an entry) and partition into
+   * trailing (initialSplit=true) and split groups. Each trailing entry gets
+   * its own scheduler; split groups land in Task 10.
+   */
+  _setupEmissions() {
+    const shrapnel = this._extraParam.shrapnel;
+    if (!shrapnel) return;
+    for (const key of Object.keys(shrapnel)) {
+      if (key === 'FXID') continue;
+      const info = shrapnel[key];
+      if (!info || info === '') continue;
+      const barrage = this._barrages[info.barrage_ID];
+      const child = this._bulletTemplates[info.bullet_ID];
+      if (!barrage || !child) continue;
+
+      if (info.initialSplit) {
+        this._trailing.push({
+          info, barrage, child,
+          shotsFired: 0,
+          totalShots: (barrage.primal_repeat ?? 0) + 1,
+          nextShotTime: barrage.first_delay ?? 0,
+          currentInterval: barrage.delay ?? 0,
+          deltaInterval: barrage.delta_delay ?? 0,
+        });
+      } else {
+        this._splitGroups.push({ info, barrage, child, emitted: false });
+      }
+    }
+  }
+
+  /**
+   * Drain a trailing record's queue against the current timeElapsed. Each
+   * fire pushes one child spec onto _pendingEmits. The interval is the
+   * arithmetic series delay, delay+delta, delay+2*delta, ... matching the
+   * Lua factory's per-record scheduler.
+   */
+  _drainTrailing(rec) {
+    while (rec.shotsFired < rec.totalShots && this.timeElapsed > rec.nextShotTime) {
+      this._emitChild(rec.info, rec.barrage, rec.child, rec.shotsFired);
+      rec.shotsFired += 1;
+      rec.nextShotTime += rec.currentInterval;
+      rec.currentInterval += rec.deltaInterval;
+    }
+  }
+
+  /**
+   * Build one child spec from a shrapnel record (trailing or split) and push
+   * it onto _pendingEmits. The angle composes:
+   *   - reaim:        atan2(target - spawnAtFire) + barrage.angle
+   *   - inheritAngle: current heading + barrage.angle
+   *   - else:         barrage.angle
+   * plus a per-index delta_angle for spread, plus shrapnelInfo.rotateOffset.
+   *
+   * Position: child spawns at the parent's current position (game coords);
+   * the engine's onEmit adapter converts to screen for createBullet.
+   */
+  _emitChild(info, barrage, child, index) {
+    let baseAngleDeg;
+    if (info.reaim && this._target) {
+      const dx = this._target.x - this.position.x;
+      const dy = this._target.y - this.position.y;
+      baseAngleDeg = Math.atan2(dy, dx) * 180 / Math.PI;
+    } else if (info.inheritAngle) {
+      baseAngleDeg = Math.atan2(this.speed.y, this.speed.x) * 180 / Math.PI;
+    } else {
+      baseAngleDeg = 0;
+    }
+    const angle = baseAngleDeg
+      + (barrage.angle ?? 0)
+      + index * (barrage.delta_angle ?? 0)
+      + (info.rotateOffset ?? 0);
+
+    this._pendingEmits.push({
+      startX: this.position.x,                       // game coords
+      startY: this.position.y,
+      angle,
+      bulletInfo: child,
+      enemyTarget: this._target ?? null,
+      inheritSpeed: info.inheritSpeed ? this.velocity : null,
+      transformChain: [],
+      parentBullet: null,
+    });
   }
 
   GetCurrentState() {
@@ -73,10 +159,10 @@ export class ShrapnelBulletUnit extends BulletUnit {
    * Mirrors Update (battleshrapnelbulletunit.lua:60-82). Branches by state:
    *
    *  - NORMAL: capture pre-Update verticalSpeed, run super.Update (which
-   *    integrates movement and tests range expiry), then check the Lua's
-   *    apex condition: vs != 0 AND prevVs * vs < 0 -> ChangeShrapnelState(SPLIT).
-   *    The `vs != 0` guard is implicit in `prevVs * vs < 0` (a product is
-   *    negative only when both factors are non-zero).
+   *    integrates movement and tests range expiry), drain trailing schedulers,
+   *    then check the Lua's apex condition: vs != 0 AND prevVs * vs < 0 ->
+   *    ChangeShrapnelState(SPLIT). The `vs != 0` guard is implicit in
+   *    `prevVs * vs < 0` (a product is negative only when both are non-zero).
    *
    *  - SPIN: transition to SPLIT if extra_param.lastTime is falsy (immediate)
    *    or if (timeElapsed - _spinStartTime) >= lastTime (Lua line 79).
@@ -88,12 +174,14 @@ export class ShrapnelBulletUnit extends BulletUnit {
     if (this._currentState === STATE.NORMAL) {
       const prevVerticalSpeed = this.verticalSpeed;
       super.Update();
+      for (const rec of this._trailing) this._drainTrailing(rec);
       if (prevVerticalSpeed * this.verticalSpeed < 0) {
         this.ChangeShrapnelState(STATE.SPLIT);
       }
       return;
     }
 
+    // SPIN branch unchanged
     if (this._currentState === STATE.SPIN) {
       const lastTime = this._extraParam.lastTime;
       if (!lastTime || (this.timeElapsed - this._spinStartTime) >= lastTime) {

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -96,6 +96,27 @@ export class ShrapnelBulletUnit extends BulletUnit {
   }
 
   /**
+   * Walk the split-group list. Each not-yet-emitted group whose deadline
+   * (splitEntry + shift_split_delay * groupIndex) has elapsed fires
+   * primal_repeat+1 children at the same instant, spread by delta_angle.
+   * Returns true if every group has emitted.
+   */
+  _drainSplitSchedule() {
+    for (let i = 0; i < this._splitGroups.length; i++) {
+      const group = this._splitGroups[i];
+      if (group.emitted) continue;
+      const delay = (group.info.shift_split_delay ?? 0) * i;
+      if (this.timeElapsed < this._splitEntryTime + delay) continue;
+      const count = (group.barrage.primal_repeat ?? 0) + 1;
+      for (let k = 0; k < count; k++) {
+        this._emitChild(group.info, group.barrage, group.child, k);
+      }
+      group.emitted = true;
+    }
+    return this._splitGroups.every((g) => g.emitted);
+  }
+
+  /**
    * Build one child spec from a shrapnel record (trailing or split) and push
    * it onto _pendingEmits. The angle composes:
    *   - reaim:        atan2(target - spawnAtFire) + barrage.angle
@@ -150,9 +171,11 @@ export class ShrapnelBulletUnit extends BulletUnit {
     this._currentState = next;
     if (next === STATE.SPIN) {
       this._spinStartTime = this.timeElapsed;
+    } else if (next === STATE.SPLIT) {
+      this._splitEntryTime = this.timeElapsed;
+    } else if (next === STATE.EXPIRE) {
+      this.reachDestFlag = true;
     }
-    // SPLIT side effect: handled in Task 10.
-    // EXPIRE side effect: handled in Task 8.
   }
 
   /**
@@ -167,8 +190,8 @@ export class ShrapnelBulletUnit extends BulletUnit {
    *  - SPIN: transition to SPLIT if extra_param.lastTime is falsy (immediate)
    *    or if (timeElapsed - _spinStartTime) >= lastTime (Lua line 79).
    *
-   *  - SPLIT / FINAL_SPLIT / EXPIRE: emission scheduling lands in Task 10.
-   *    For now, no-op so the lattice exits live and tests run.
+   *  - SPLIT: _drainSplitSchedule fires each group at its deadline; when all
+   *    groups have emitted, immediately forwards SPLIT -> FINAL_SPLIT -> EXPIRE.
    */
   Update() {
     if (this._currentState === STATE.NORMAL) {
@@ -190,7 +213,21 @@ export class ShrapnelBulletUnit extends BulletUnit {
       return;
     }
 
-    // SPLIT / FINAL_SPLIT / EXPIRE — see Task 10 for emission scheduling.
+    if (this._currentState === STATE.SPLIT) {
+      const allEmitted = this._drainSplitSchedule();
+      if (allEmitted) {
+        // Forward-only lattice: SPLIT -> FINAL_SPLIT -> EXPIRE within one
+        // Update. The Lua's emitter coordination doesn't exist here, so
+        // collapsing to immediate transition is the minimal faithful
+        // interpretation (design §State lattice).
+        this.ChangeShrapnelState(STATE.FINAL_SPLIT);
+        this.ChangeShrapnelState(STATE.EXPIRE);
+      }
+      return;
+    }
+
+    // FINAL_SPLIT / EXPIRE: nothing to do; reachDestFlag is set on entry
+    // to EXPIRE and the world culls next.
   }
 
   /**

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -13,6 +13,8 @@
  */
 
 import { BulletUnit } from '../bullet-unit.js';
+import { sqrDistance } from '../vec.js';
+import { BULLET_SPEED_CONVERT } from '../constants.js';
 
 export const STATE = Object.freeze({
   NORMAL: 'normal',
@@ -160,10 +162,18 @@ export class ShrapnelBulletUnit extends BulletUnit {
 
   /**
    * Mirrors BattleShrapnelBulletUnit:SetSpawnPosition (battleshrapnelbulletunit.lua:122-149).
-   * Only the `flare` branch is implemented in Phase 3a (directHit is
-   * 0-reached after VISION exclusion). When `flare` is set, solve
-   * convertedVelocity and verticalSpeed so the bullet lands at explodePos
-   * exactly when the first shrapnel child's hit_type.time elapses.
+   * Two branches:
+   *
+   *  - `flare` (§C8): solve convertedVelocity + verticalSpeed so the bullet
+   *    lands at explodePos exactly when the first shrapnel child's
+   *    hit_type.time elapses. (directHit is 0-reached after VISION exclusion.)
+   *
+   *  - Default (gravity bullet, no flare): apply the base game's gravity
+   *    initial vertical speed `-0.5 * gravity * 60 / convertedVelocity`
+   *    (battlebulletunit.lua:511-523, spec §B8). Without this the parent
+   *    launches with verticalSpeed=0, immediately falls under gravity,
+   *    never arcs — Kirishima skill 11270 was hitting this. The legacy
+   *    GravityBehavior applies the same formula (sim.engine.bullet.factory.js:371).
    */
   SetSpawnPosition() {
     if (this._extraParam.flare && this._explodePos) {
@@ -190,6 +200,15 @@ export class ShrapnelBulletUnit extends BulletUnit {
         const t = dist / this._convertedVelocity;
         this.verticalSpeed = h / t - 0.5 * this.gravity * t;
       }
+      return;
+    }
+
+    // Default gravity-init for a non-flare shrapnel parent. Gates on
+    // gravity != 0 and velocity > 0 to avoid div-by-zero for gravity-less
+    // shrapnel (rare; would otherwise misbehave silently).
+    if (this.gravity !== 0 && this.velocity > 0) {
+      const convertedVelocity = this.velocity * BULLET_SPEED_CONVERT;
+      this.verticalSpeed = -0.5 * this.gravity * 60 / convertedVelocity;
     }
   }
 
@@ -217,13 +236,15 @@ export class ShrapnelBulletUnit extends BulletUnit {
   }
 
   /**
-   * Mirrors Update (battleshrapnelbulletunit.lua:60-82). Branches by state:
+   * Mirrors Update (battleshrapnelbulletunit.lua:60-82). Branches by state.
    *
-   *  - NORMAL: capture pre-Update verticalSpeed, run super.Update (which
-   *    integrates movement and tests range expiry), drain trailing schedulers,
-   *    then check the Lua's apex condition: vs != 0 AND prevVs * vs < 0 ->
-   *    ChangeShrapnelState(SPLIT). The `vs != 0` guard is implicit in
-   *    `prevVs * vs < 0` (a product is negative only when both are non-zero).
+   *  - NORMAL: integrate position + altitude inline (NOT via super.Update —
+   *    the base's `altitude <= BOMB_DETONATE_HEIGHT` branch is wrong for
+   *    shrapnel, which spawn at altitude 0 and would die on tick 1 once
+   *    gravity is applied; shrapnel use range expiry instead). Range expiry
+   *    OR apex sign-flip transitions to SPLIT — the legacy ShrapnelBehavior's
+   *    primary trigger was range, secondary was apex; the spec's apex-only
+   *    framing was incomplete.
    *
    *  - SPIN: transition to SPLIT if extra_param.lastTime is falsy (immediate)
    *    or if (timeElapsed - _spinStartTime) >= lastTime (Lua line 79).
@@ -234,9 +255,19 @@ export class ShrapnelBulletUnit extends BulletUnit {
   Update() {
     if (this._currentState === STATE.NORMAL) {
       const prevVerticalSpeed = this.verticalSpeed;
-      super.Update();
+      // Inline the base integration order (updateSpeed → position →
+      // altitude) but skip the base's range-OR-altitude expiry check.
+      this.updateSpeed();
+      this.position.x += this.speed.x;
+      this.position.y += this.speed.y;
+      this.altitude += this.verticalSpeed;
+
       for (const rec of this._trailing) this._drainTrailing(rec);
-      if (prevVerticalSpeed * this.verticalSpeed < 0) {
+
+      const rangeExpired =
+        sqrDistance(this.spawnPos, this.position) > this.sqrRange;
+      const apexFlip = prevVerticalSpeed * this.verticalSpeed < 0;
+      if (rangeExpired || apexFlip) {
         this.ChangeShrapnelState(STATE.SPLIT);
       }
       return;

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -102,14 +102,17 @@ export class ShrapnelBulletUnit extends BulletUnit {
    * Returns true if every group has emitted.
    */
   _drainSplitSchedule() {
+    const skipEmit = this._extraParam.fragile === 1;
     for (let i = 0; i < this._splitGroups.length; i++) {
       const group = this._splitGroups[i];
       if (group.emitted) continue;
       const delay = (group.info.shift_split_delay ?? 0) * i;
       if (this.timeElapsed < this._splitEntryTime + delay) continue;
-      const count = (group.barrage.primal_repeat ?? 0) + 1;
-      for (let k = 0; k < count; k++) {
-        this._emitChild(group.info, group.barrage, group.child, k);
+      if (!skipEmit) {
+        const count = (group.barrage.primal_repeat ?? 0) + 1;
+        for (let k = 0; k < count; k++) {
+          this._emitChild(group.info, group.barrage, group.child, k);
+        }
       }
       group.emitted = true;
     }

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -158,6 +158,41 @@ export class ShrapnelBulletUnit extends BulletUnit {
     });
   }
 
+  /**
+   * Mirrors BattleShrapnelBulletUnit:SetSpawnPosition (battleshrapnelbulletunit.lua:122-149).
+   * Only the `flare` branch is implemented in Phase 3a (directHit is
+   * 0-reached after VISION exclusion). When `flare` is set, solve
+   * convertedVelocity and verticalSpeed so the bullet lands at explodePos
+   * exactly when the first shrapnel child's hit_type.time elapses.
+   */
+  SetSpawnPosition() {
+    if (this._extraParam.flare && this._explodePos) {
+      // SetSpawnPosition runs at construction — this.altitude is still the spawn altitude.
+      const shrapnelArr = this._extraParam.shrapnel;
+      const firstKey = shrapnelArr
+        ? Object.keys(shrapnelArr).find((k) => k !== 'FXID')
+        : null;
+      const firstEntry = firstKey ? shrapnelArr[firstKey] : null;
+      const childTpl = firstEntry
+        ? this._bulletTemplates[firstEntry.bullet_ID]
+        : null;
+      if (childTpl) {
+        const CALC_FPS = 30;
+        const childGrav = Math.abs(childTpl.extra_param?.gravity ?? -0.0005);
+        const childTime = childTpl.hit_type?.time ?? 0;
+        const dx = this._explodePos.x - this.spawnPos.x;
+        const dy = this._explodePos.y - this.spawnPos.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const h = 0.5 * childGrav * (childTime * CALC_FPS) ** 2 - this.altitude;
+        this._convertedVelocity = Math.sqrt(
+          -0.5 * this.gravity * dist * dist / h
+        );
+        const t = dist / this._convertedVelocity;
+        this.verticalSpeed = h / t - 0.5 * this.gravity * t;
+      }
+    }
+  }
+
   GetCurrentState() {
     return this._currentState;
   }

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -1,0 +1,82 @@
+/**
+ * physics/bullets/shrapnel.js
+ * ShrapnelBulletUnit — bullet type 5. Mirrors BattleShrapnelBulletUnit
+ * (battleshrapnelbulletunit.lua). Implements the monotonic state lattice
+ * NORMAL -> SPIN -> SPLIT -> FINAL_SPLIT -> EXPIRE (spec §C6), gated
+ * movement (NORMAL only), game-time emission scheduling, and the §C8
+ * SetSpawnPosition overrides (directHit / flare).
+ *
+ * Pure: no DOM, no wall-clock. Child bullets are emitted via _pendingEmits;
+ * the World's onEmit callback hands each spec back to the engine's
+ * createBullet dispatch (so children flow through the strangler regardless
+ * of their type).
+ */
+
+import { BulletUnit } from '../bullet-unit.js';
+
+export const STATE = Object.freeze({
+  NORMAL: 'normal',
+  SPIN: 'spin',
+  SPLIT: 'split',
+  FINAL_SPLIT: 'final_split',
+  EXPIRE: 'expire',
+});
+
+export const STATE_PRIORITY = Object.freeze({
+  [STATE.NORMAL]: 1,
+  [STATE.SPIN]: 2,
+  [STATE.SPLIT]: 3,
+  [STATE.FINAL_SPLIT]: 4,
+  [STATE.EXPIRE]: 5,
+});
+
+export class ShrapnelBulletUnit extends BulletUnit {
+  constructor(opts = {}) {
+    super(opts);
+    this._extraParam = opts.extraParam ?? {};
+    this._explodePos = opts.explodePos ?? null;
+    this._bulletTemplates = opts.bulletTemplates ?? {};
+    this._currentState = STATE.NORMAL;
+    this._spinStartTime = -1;
+    this._pendingEmits = [];
+
+    // Emission state is initialised by _setupEmissions() — implemented in
+    // Task 9 (trailing) and Task 10 (split). For Task 7 these fields are
+    // declared so the rest of the class can refer to them safely.
+    this._trailing = [];
+    this._splitGroups = [];
+    this._splitEntryTime = -1;
+  }
+
+  GetCurrentState() {
+    return this._currentState;
+  }
+
+  /**
+   * Mirrors ChangeShrapnelState (battleshrapnelbulletunit.lua:84-96). The
+   * monotonic priority guard enforces forward-only transitions; same or
+   * backward calls are a no-op. Side effects: entering SPIN records
+   * _spinStartTime; entering SPLIT records _splitEntryTime (Task 10);
+   * entering EXPIRE flags reachDestFlag (Task 8 wiring).
+   */
+  ChangeShrapnelState(next) {
+    if (STATE_PRIORITY[next] <= STATE_PRIORITY[this._currentState]) return;
+    this._currentState = next;
+    if (next === STATE.SPIN) {
+      this._spinStartTime = this.timeElapsed;
+    }
+    // SPLIT side effect: handled in Task 10.
+    // EXPIRE side effect: handled in Task 8.
+  }
+
+  /**
+   * Returns the queued child specs and clears the queue. Called once per
+   * tick by World.step() after all Updates.
+   */
+  drainEmits() {
+    if (this._pendingEmits.length === 0) return [];
+    const out = this._pendingEmits;
+    this._pendingEmits = [];
+    return out;
+  }
+}

--- a/public/js/simulators/physics/bullets/shrapnel.js
+++ b/public/js/simulators/physics/bullets/shrapnel.js
@@ -70,6 +70,42 @@ export class ShrapnelBulletUnit extends BulletUnit {
   }
 
   /**
+   * Mirrors Update (battleshrapnelbulletunit.lua:60-82). Branches by state:
+   *
+   *  - NORMAL: capture pre-Update verticalSpeed, run super.Update (which
+   *    integrates movement and tests range expiry), then check the Lua's
+   *    apex condition: vs != 0 AND prevVs * vs < 0 -> ChangeShrapnelState(SPLIT).
+   *    The `vs != 0` guard is implicit in `prevVs * vs < 0` (a product is
+   *    negative only when both factors are non-zero).
+   *
+   *  - SPIN: transition to SPLIT if extra_param.lastTime is falsy (immediate)
+   *    or if (timeElapsed - _spinStartTime) >= lastTime (Lua line 79).
+   *
+   *  - SPLIT / FINAL_SPLIT / EXPIRE: emission scheduling lands in Task 10.
+   *    For now, no-op so the lattice exits live and tests run.
+   */
+  Update() {
+    if (this._currentState === STATE.NORMAL) {
+      const prevVerticalSpeed = this.verticalSpeed;
+      super.Update();
+      if (prevVerticalSpeed * this.verticalSpeed < 0) {
+        this.ChangeShrapnelState(STATE.SPLIT);
+      }
+      return;
+    }
+
+    if (this._currentState === STATE.SPIN) {
+      const lastTime = this._extraParam.lastTime;
+      if (!lastTime || (this.timeElapsed - this._spinStartTime) >= lastTime) {
+        this.ChangeShrapnelState(STATE.SPLIT);
+      }
+      return;
+    }
+
+    // SPLIT / FINAL_SPLIT / EXPIRE — see Task 10 for emission scheduling.
+  }
+
+  /**
    * Returns the queued child specs and clears the queue. Called once per
    * tick by World.step() after all Updates.
    */

--- a/public/js/simulators/physics/world.js
+++ b/public/js/simulators/physics/world.js
@@ -12,6 +12,14 @@ import { createBulletUnit } from './bullet-registry.js';
 export class World {
   constructor() {
     this.bullets = [];
+    /**
+     * Optional emit callback. A unit that produces children mid-tick (e.g.
+     * ShrapnelBulletUnit on SPLIT) pushes child specs onto its own
+     * _pendingEmits queue and returns them from drainEmits(); step() routes
+     * each through onEmit so the view driver can run them through its
+     * existing createBullet dispatch. Null = no children supported.
+     */
+    this.onEmit = null;
   }
 
   /**
@@ -62,17 +70,31 @@ export class World {
   }
 
   /**
-   * Advance the whole simulation by one fixed tick, then cull expired units.
+   * Advance the whole simulation by one fixed tick.
    *
-   * Invariant: no unit is spawned mid-tick — every bullet present at the start
-   * of step() is stepped exactly once. Phase 3 (shrapnel split, transform)
-   * introduces mid-tick spawning; when it does, decide explicitly whether a
-   * freshly-spawned unit steps in the same tick or the next.
+   * Three phases: (1) Update every bullet alive at tick start, (2) drain
+   * each one's emit queue through onEmit, (3) cull expired units.
+   *
+   * Length-cached iteration is the mid-tick spawn invariant: a child
+   * spawned via onEmit appends to `bullets` past index `n` and Updates on
+   * the NEXT step(), not this one. This matches the Lua's loop semantics —
+   * `for ... in pairs(BulletList)` does not see newly-inserted entries on
+   * the current iteration — and it makes split timing deterministic.
    */
   step() {
-    for (const bullet of this.bullets) {
-      bullet.timeElapsed += TICK_SECONDS;
-      bullet.Update();
+    const n = this.bullets.length;
+    for (let i = 0; i < n; i++) {
+      this.bullets[i].timeElapsed += TICK_SECONDS;
+      this.bullets[i].Update();
+    }
+    if (this.onEmit) {
+      for (let i = 0; i < n; i++) {
+        const b = this.bullets[i];
+        if (b.drainEmits) {
+          const emits = b.drainEmits();
+          for (const spec of emits) this.onEmit(spec);
+        }
+      }
     }
     this.bullets = this.bullets.filter((b) => !b.reachDestFlag);
   }

--- a/public/js/simulators/physics/world.js
+++ b/public/js/simulators/physics/world.js
@@ -41,6 +41,9 @@ export class World {
     }
     const unit = createBulletUnit(opts.type, opts);
     unit.FixRange();
+    if (typeof unit.SetSpawnPosition === 'function') {
+      unit.SetSpawnPosition();
+    }
     unit.InitSpeed();
     this.bullets.push(unit);
     return unit;

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -673,6 +673,10 @@ export class BulletEngine {
             barrageAngle: barrageAngle,
             target: enemyTarget,
             // Phase 3a additions — subclasses pick what they need; base ignores.
+            // gravity comes from extra_param for shrapnel parents (e.g. bullet
+            // 19920 carries `-0.05`). Undefined for cannon / torpedo / effect
+            // → BulletUnit defaults to 0, no change.
+            gravity: bulletInfo.extra_param?.gravity,
             extraParam: bulletInfo.extra_param,
             hitTypeTime: bulletInfo.hit_type?.time,
             explodePos: options.explodePos ?? options.airdropData?.explodePos,

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -70,6 +70,18 @@ export class BulletEngine {
         // through one shared loop; the legacy per-bullet rAF path runs
         // everything else. See dev/active/2026-05-17-weapon-physics-rework.md.
         this.world = new World();
+        // ShrapnelBulletUnit.drainEmits returns child specs in GAME coords.
+        // createBullet's contract is SCREEN coords; convert once here so the
+        // engine's existing dispatch (predicates -> _createWorldBullet ->
+        // screenToGame, or legacy path -> screen) keeps its interface.
+        this.world.onEmit = (spec) => {
+            const screen = this.gameToScreen(spec.startX, spec.startY);
+            this.createBullet({
+                ...spec,
+                startX: screen.x,
+                startY: screen.y,
+            });
+        };
         this._worldViews = new Map();   // BulletUnit -> { element, bulletInfo, baseWidth, baseHeight }
         this._worldLoopId = null;       // rAF id of the shared loop, null when idle
         this._worldAccumulatorMs = 0;   // unspent real time carried between frames
@@ -175,6 +187,15 @@ export class BulletEngine {
         // DOM and rendering; EffectBulletUnit's hit_type.time cap drives
         // expiry alongside the base range check.
         if (this._isMigratedEffect(bulletInfo, options)) {
+            return this._createWorldBullet(options);
+        }
+
+        // Route a type-5 SHRAPNEL through the faithful physics core. Children
+        // emit via the world's onEmit callback (wired in this task's Step 4),
+        // which routes each child through createBullet so they too flow through
+        // the strangler — a child of a migrated type goes to the core, a child
+        // of an unmigrated type goes to the legacy path.
+        if (this._isMigratedShrapnel(bulletInfo, options)) {
             return this._createWorldBullet(options);
         }
 
@@ -594,6 +615,22 @@ export class BulletEngine {
     }
 
     /**
+     * True for a type-5 SHRAPNEL routed through the faithful physics core
+     * (spec §C6 / §C7 / §C8). Predicate-conservative — excludes:
+     *   - rangeAA  (AA-adjacent, out of scope per parent spec)
+     *   - out_bound === 3 (VISION) — covers the 6 reached VISION shrapnel
+     *     including the 2 directHit cases (skill_weapon scan, 2026-05-20)
+     *   - inheritSpeed and transform chains (legacy carries these)
+     */
+    _isMigratedShrapnel(bulletInfo, options) {
+        return bulletInfo.type === 5
+            && !bulletInfo.extra_param?.rangeAA
+            && bulletInfo.out_bound !== 3
+            && options.inheritSpeed == null
+            && (!options.transformChain || options.transformChain.length === 0);
+    }
+
+    /**
      * Build the DOM element for a physics-core bullet: the base `bullet`
      * class, the skin modle_ID class, and the bullet-type class so a migrated
      * bullet keeps its type styling. Size and position are set by the caller.
@@ -640,6 +677,7 @@ export class BulletEngine {
             hitTypeTime: bulletInfo.hit_type?.time,
             explodePos: options.explodePos ?? options.airdropData?.explodePos,
             bulletTemplates: this.allBullets,
+            barrages: this.allBarrages,                  // NEW for shrapnel
             parentBullet: options.parentBullet,
         });
         if (!unit) return null;

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -170,6 +170,14 @@ export class BulletEngine {
             return this._createWorldBomb(options);
         }
 
+        // Route a type-9 effect bullet to the faithful physics core — fixes
+        // the lingering red-dot bug. The shared _createWorldBullet handles
+        // DOM and rendering; EffectBulletUnit's hit_type.time cap drives
+        // expiry alongside the base range check.
+        if (this._isMigratedEffect(bulletInfo, options)) {
+            return this._createWorldBullet(options);
+        }
+
         // Create bullet DOM element
         const bulletElement = document.createElement('div');
         bulletElement.className = 'bullet';
@@ -573,6 +581,19 @@ export class BulletEngine {
     }
 
     /**
+     * True for a type-9 EFFECT bullet routed through the faithful physics
+     * core. EffectBulletUnit inherits the base movement and adds a lifetime
+     * cap from hit_type.time — fixes the lingering red-dot bug (spec §C8 /
+     * bug map row 4). Stays predicate-conservative: a type-9 with inherited
+     * speed or a transform chain stays on the legacy path.
+     */
+    _isMigratedEffect(bulletInfo, options) {
+        return bulletInfo.type === 9
+            && options.inheritSpeed == null
+            && (!options.transformChain || options.transformChain.length === 0);
+    }
+
+    /**
      * Build the DOM element for a physics-core bullet: the base `bullet`
      * class, the skin modle_ID class, and the bullet-type class so a migrated
      * bullet keeps its type styling. Size and position are set by the caller.
@@ -614,6 +635,12 @@ export class BulletEngine {
             acceleration: bulletInfo.acceleration,
             barrageAngle: barrageAngle,
             target: enemyTarget,
+            // Phase 3a additions — subclasses pick what they need; base ignores.
+            extraParam: bulletInfo.extra_param,
+            hitTypeTime: bulletInfo.hit_type?.time,
+            explodePos: options.explodePos ?? options.airdropData?.explodePos,
+            bulletTemplates: this.allBullets,
+            parentBullet: options.parentBullet,
         });
         if (!unit) return null;
 

--- a/tests/physics/bullet-registry.test.js
+++ b/tests/physics/bullet-registry.test.js
@@ -44,3 +44,11 @@ test('type 9 maps to EffectBulletUnit', async () => {
   const unit = createBulletUnit(9, { velocity: 10, yAngle: 0, range: 10 });
   assert.ok(unit instanceof EffectBulletUnit);
 });
+
+test('type 5 maps to ShrapnelBulletUnit', async () => {
+  const { ShrapnelBulletUnit } = await import(
+    '../../public/js/simulators/physics/bullets/shrapnel.js'
+  );
+  const unit = createBulletUnit(5, { velocity: 10, yAngle: 0, range: 10 });
+  assert.ok(unit instanceof ShrapnelBulletUnit);
+});

--- a/tests/physics/bullet-registry.test.js
+++ b/tests/physics/bullet-registry.test.js
@@ -36,3 +36,11 @@ test('a TorpedoBulletUnit is also a BulletUnit', () => {
   const u = createBulletUnit(3, { velocity: 10, yAngle: 0 });
   assert.ok(u instanceof BulletUnit);
 });
+
+test('type 9 maps to EffectBulletUnit', async () => {
+  const { EffectBulletUnit } = await import(
+    '../../public/js/simulators/physics/bullets/effect.js'
+  );
+  const unit = createBulletUnit(9, { velocity: 10, yAngle: 0, range: 10 });
+  assert.ok(unit instanceof EffectBulletUnit);
+});

--- a/tests/physics/effect.test.js
+++ b/tests/physics/effect.test.js
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectBulletUnit } from '../../public/js/simulators/physics/bullets/effect.js';
+import { TICK_SECONDS } from '../../public/js/simulators/physics/constants.js';
+
+test('EffectBulletUnit: extends BulletUnit movement (calcSpeed + Update advances position)', () => {
+  const b = new EffectBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.position.x, 10);            // 50 * 0.2
+});
+
+test('EffectBulletUnit: lifetime cap expires the bullet at hit_type.time', () => {
+  // hitTypeTime = 3 ticks * TICK_SECONDS = 0.1s. Range 1000 keeps range expiry
+  // out of the way so the cap is the only expiry path.
+  const b = new EffectBulletUnit({
+    velocity: 1, yAngle: 0, range: 1000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    hitTypeTime: 3 * TICK_SECONDS,
+  });
+  b.FixRange();
+  b.InitSpeed();
+  for (let i = 0; i < 2; i++) {
+    b.timeElapsed += TICK_SECONDS;
+    b.Update();
+  }
+  assert.equal(b.reachDestFlag, false, 'still alive at 2 ticks');
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.reachDestFlag, true, 'expired at hitTypeTime');
+});
+
+test('EffectBulletUnit: range expiry still applies when no lifetime cap', () => {
+  // hitTypeTime null -> only range expiry. range 5 -> sqrRange 25, speed 10/tick.
+  const b = new EffectBulletUnit({
+    velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    hitTypeTime: null,
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();                                 // x=10, sqrDist 100 > 25 -> expire
+  assert.equal(b.reachDestFlag, true);
+});
+
+test('EffectBulletUnit: long-lifetime + short-range expires by range', () => {
+  // hitTypeTime way out (100 ticks) but range 5 -> expires by range first.
+  const b = new EffectBulletUnit({
+    velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    hitTypeTime: 100 * TICK_SECONDS,
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.reachDestFlag, true, 'range fires before lifetime cap');
+});
+
+test('EffectBulletUnit: hitTypeTime <= 0 is treated as no cap (range-only)', () => {
+  // The data uses `hit_type.time: -1` as an "infinite lifetime" sentinel
+  // (17 templates, 1 reached: bullet 19010). Without the <= 0 guard the
+  // cap would be -1 and `timeElapsed >= -1` would fire on tick 1.
+  const negCap = new EffectBulletUnit({
+    velocity: 1, yAngle: 0, range: 1000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    hitTypeTime: -1,
+  });
+  negCap.FixRange();
+  negCap.InitSpeed();
+  for (let i = 0; i < 5; i++) {
+    negCap.timeElapsed += TICK_SECONDS;
+    negCap.Update();
+  }
+  assert.equal(negCap.reachDestFlag, false, '-1 cap is treated as no cap');
+
+  // Zero is also "no cap" by the same rule.
+  const zeroCap = new EffectBulletUnit({
+    velocity: 1, yAngle: 0, range: 1000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    hitTypeTime: 0,
+  });
+  zeroCap.FixRange();
+  zeroCap.InitSpeed();
+  zeroCap.timeElapsed += TICK_SECONDS;
+  zeroCap.Update();
+  assert.equal(zeroCap.reachDestFlag, false, '0 cap is treated as no cap');
+});
+
+test('EffectBulletUnit: SetExplodePosition stores _explodePos, does not move the bullet', () => {
+  const b = new EffectBulletUnit({
+    velocity: 0, yAngle: 0, range: 10, rangeOffset: 0,
+    spawnX: 5, spawnY: 5,
+  });
+  b.SetExplodePosition({ x: 99, y: 99 });
+  assert.deepEqual(b._explodePos, { x: 99, y: 99 });
+  assert.deepEqual(b.position, { x: 5, y: 5 }, 'movement unaffected');
+});

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -104,6 +104,9 @@ test('Update: movement does NOT run outside NORMAL', () => {
 test('Update: range expiry does NOT fire outside NORMAL', () => {
   // Pre-stretch the bullet past its range, then leave NORMAL — IsOutRange
   // must be inert so the bullet survives in SPLIT until SPLIT-driven expiry.
+  // With zero split groups, SPLIT auto-forwards to EXPIRE (vacuously all
+  // groups emitted). reachDestFlag is set by the SPLIT->EXPIRE path, not
+  // by IsOutRange — the range check is still muted outside NORMAL.
   const b = new ShrapnelBulletUnit({
     velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
     spawnX: 0, spawnY: 0, extraParam: {},
@@ -114,7 +117,9 @@ test('Update: range expiry does NOT fire outside NORMAL', () => {
   b.ChangeShrapnelState(STATE.SPLIT);
   b.timeElapsed += TICK_SECONDS;
   b.Update();
-  assert.equal(b.reachDestFlag, false, 'IsOutRange muted outside NORMAL');
+  // SPLIT with no groups -> immediate EXPIRE via split completion, not IsOutRange.
+  assert.equal(b.GetCurrentState(), STATE.EXPIRE, 'SPLIT auto-expires when no groups');
+  assert.equal(b.reachDestFlag, true, 'reachDestFlag set by SPLIT->EXPIRE, not IsOutRange');
 });
 
 test('NORMAL -> SPLIT on apex (clean sign-flip without zero crossing)', () => {
@@ -255,4 +260,104 @@ test('Trailing: no trailing record -> no emission', () => {
     b.Update();
   }
   assert.equal(b.drainEmits().length, 0);
+});
+
+test('Split: a single group emits primal_repeat+1 children at SPLIT entry', () => {
+  // primal_repeat = 2 -> 3 children at the same tick.
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = {
+    barrage_ID: 1, primal_repeat: 2,
+    first_delay: 0, delay: 0, delta_delay: 0,
+    angle: 0, delta_angle: 10,
+  };
+  const extraParam = {
+    shrapnel: [
+      { initialSplit: false, barrage_ID: 1, bullet_ID: 'B' },
+    ],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPLIT);                       // external trigger
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  const emits = b.drainEmits();
+  assert.equal(emits.length, 3, 'primal_repeat+1 children at one instant');
+  // delta_angle spread: 0, 10, 20.
+  assert.equal(emits[0].angle, 0);
+  assert.equal(emits[1].angle, 10);
+  assert.equal(emits[2].angle, 20);
+});
+
+test('Split: shift_split_delay staggers different groups by group index', () => {
+  // Two groups, both 1 child, shift_split_delay = 2 ticks each.
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = {
+    barrage_ID: 1, primal_repeat: 0, first_delay: 0, delay: 0, delta_delay: 0,
+    angle: 0, delta_angle: 0,
+  };
+  const extraParam = {
+    shrapnel: [
+      { initialSplit: false, barrage_ID: 1, bullet_ID: 'B', shift_split_delay: 2 * TICK_SECONDS },
+      { initialSplit: false, barrage_ID: 1, bullet_ID: 'B', shift_split_delay: 2 * TICK_SECONDS },
+    ],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPLIT);
+  // Tick 1: group 0 (delay 0 * 2 = 0) fires.
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  let emits = b.drainEmits();
+  assert.equal(emits.length, 1);
+  // Tick 2: group 1 deadline = 0 + 2 ticks = 2/30. timeElapsed = 2/30 -> fires.
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  emits = b.drainEmits();
+  assert.equal(emits.length, 1);
+  // Tick 3: nothing left.
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  emits = b.drainEmits();
+  assert.equal(emits.length, 0);
+});
+
+test('Split: after all groups emit -> FINAL_SPLIT -> EXPIRE -> reachDestFlag', () => {
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = {
+    barrage_ID: 1, primal_repeat: 0, first_delay: 0, delay: 0, delta_delay: 0,
+    angle: 0, delta_angle: 0,
+  };
+  const extraParam = {
+    shrapnel: [
+      { initialSplit: false, barrage_ID: 1, bullet_ID: 'B' },
+    ],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPLIT);
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.EXPIRE);
+  assert.equal(b.reachDestFlag, true);
 });

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -165,3 +165,94 @@ test('SPIN -> SPLIT after lastTime seconds when positive', () => {
   b.Update();
   assert.equal(b.GetCurrentState(), STATE.SPLIT, 'transition at lastTime');
 });
+
+test('Trailing: a record with initialSplit=true emits during NORMAL', () => {
+  // Two-shot trailing record: shots at t = first_delay and t = first_delay + delay.
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = {
+    barrage_ID: 1, primal_repeat: 1, first_delay: 0, delay: TICK_SECONDS, delta_delay: 0,
+    angle: 0, delta_angle: 0,
+  };
+  const extraParam = {
+    shrapnel: [
+      { initialSplit: true, barrage_ID: 1, bullet_ID: 'B', inheritAngle: false, reaim: false },
+    ],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+
+  // Tick 1: t = 1/30 >= first_delay 0 -> emit child #0
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  let emits = b.drainEmits();
+  assert.equal(emits.length, 1, 'first shot fired');
+  assert.equal(emits[0].bulletInfo, child);
+  // Tick 2: t = 2/30. next shot was scheduled at first_delay + delay = 1/30. Emit #1.
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  emits = b.drainEmits();
+  assert.equal(emits.length, 1, 'second shot fired');
+  // Tick 3: no more shots queued (totalShots = primal_repeat+1 = 2 fired).
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  emits = b.drainEmits();
+  assert.equal(emits.length, 0);
+});
+
+test('Trailing: delta_delay grows the interval each shot', () => {
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = {
+    barrage_ID: 1, primal_repeat: 2,         // -> 3 shots
+    first_delay: 0,
+    delay: TICK_SECONDS,                     // initial interval
+    delta_delay: TICK_SECONDS,               // each subsequent interval grows by 1 tick
+    angle: 0, delta_angle: 0,
+  };
+  const extraParam = {
+    shrapnel: [
+      { initialSplit: true, barrage_ID: 1, bullet_ID: 'B' },
+    ],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+
+  const shotTicks = [];
+  for (let tick = 1; tick <= 10; tick++) {
+    b.timeElapsed += TICK_SECONDS;
+    b.Update();
+    const emits = b.drainEmits();
+    if (emits.length > 0) shotTicks.push(tick);
+  }
+  // Shot 0 at first_delay (0)        -> tick 1
+  // Shot 1 at 0 + delay (1)          -> tick 2
+  // Shot 2 at 0 + delay + (delay+delta) (1 + 2) -> tick 4
+  assert.deepEqual(shotTicks, [1, 2, 4]);
+});
+
+test('Trailing: no trailing record -> no emission', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.FixRange();
+  b.InitSpeed();
+  for (let i = 0; i < 5; i++) {
+    b.timeElapsed += TICK_SECONDS;
+    b.Update();
+  }
+  assert.equal(b.drainEmits().length, 0);
+});

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -361,3 +361,28 @@ test('Split: after all groups emit -> FINAL_SPLIT -> EXPIRE -> reachDestFlag', (
   assert.equal(b.GetCurrentState(), STATE.EXPIRE);
   assert.equal(b.reachDestFlag, true);
 });
+
+test('fragile=1: SPLIT trigger emits no children but completes the lattice to EXPIRE', () => {
+  const child = { type: 1, velocity: 10, range: 50 };
+  const barrage = { barrage_ID: 1, primal_repeat: 0, angle: 0, delta_angle: 0 };
+  const extraParam = {
+    fragile: 1,
+    shrapnel: [{ initialSplit: false, barrage_ID: 1, bullet_ID: 'B' }],
+  };
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0,
+    extraParam,
+    bulletTemplates: { B: child },
+    barrages: { 1: barrage },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPLIT);
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.drainEmits().length, 0, 'no children emitted');
+  // Visual-only split: the bullet still completes the lattice, just without
+  // child specs.
+  assert.equal(b.GetCurrentState(), STATE.EXPIRE);
+});

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -5,6 +5,7 @@ import {
   STATE,
   STATE_PRIORITY,
 } from '../../public/js/simulators/physics/bullets/shrapnel.js';
+import { TICK_SECONDS } from '../../public/js/simulators/physics/constants.js';
 
 test('ShrapnelBulletUnit: starts in NORMAL', () => {
   const b = new ShrapnelBulletUnit({
@@ -59,4 +60,108 @@ test('ChangeShrapnelState: entering SPIN records timeElapsed as spinStartTime', 
   b.timeElapsed = 1.5;
   b.ChangeShrapnelState(STATE.SPIN);
   assert.equal(b._spinStartTime, 1.5);
+});
+
+test('Update: movement runs in NORMAL — position advances', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 1000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.position.x, 10);
+});
+
+test('Update: range expiry fires in NORMAL (sets reachDestFlag)', () => {
+  // range 5 -> sqrRange 25; speed 10/tick -> expires in 1 tick.
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.reachDestFlag, true);
+});
+
+test('Update: movement does NOT run outside NORMAL', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 1000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPLIT);
+  const px = b.position.x;
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.position.x, px, 'position unchanged outside NORMAL');
+});
+
+test('Update: range expiry does NOT fire outside NORMAL', () => {
+  // Pre-stretch the bullet past its range, then leave NORMAL — IsOutRange
+  // must be inert so the bullet survives in SPLIT until SPLIT-driven expiry.
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.position.x = 999;                                // way past range
+  b.ChangeShrapnelState(STATE.SPLIT);
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.reachDestFlag, false, 'IsOutRange muted outside NORMAL');
+});
+
+test('NORMAL -> SPLIT on apex (clean sign-flip without zero crossing)', () => {
+  // Launch with vs that produces an unambiguous flip: vs=0.07, gravity=-0.05
+  //   tick 1 pre: 0.07, post: 0.02  -> 0.07 * 0.02 > 0, no flip
+  //   tick 2 pre: 0.02, post: -0.03 -> 0.02 * -0.03 < 0, FLIP
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0, gravity: -0.05,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.verticalSpeed = 0.07;
+  b.FixRange();
+  b.InitSpeed();
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.NORMAL);
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.SPLIT, 'apex flip enters SPLIT');
+});
+
+test('SPIN -> SPLIT immediately when lastTime is falsy', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: { lastTime: 0 },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPIN);
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.SPLIT, 'falsy lastTime -> immediate');
+});
+
+test('SPIN -> SPLIT after lastTime seconds when positive', () => {
+  // lastTime = 2 ticks. SPIN enters at t=0, transition expected at t >= 2 ticks.
+  const b = new ShrapnelBulletUnit({
+    velocity: 10, yAngle: 0, range: 10000, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: { lastTime: 2 * TICK_SECONDS },
+  });
+  b.FixRange();
+  b.InitSpeed();
+  b.ChangeShrapnelState(STATE.SPIN);                 // _spinStartTime = 0
+  b.timeElapsed += TICK_SECONDS;                     // t = 1/30
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.SPIN, 'still in SPIN at 1 tick');
+  b.timeElapsed += TICK_SECONDS;                     // t = 2/30
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.SPLIT, 'transition at lastTime');
 });

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ShrapnelBulletUnit,
+  STATE,
+  STATE_PRIORITY,
+} from '../../public/js/simulators/physics/bullets/shrapnel.js';
+
+test('ShrapnelBulletUnit: starts in NORMAL', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  assert.equal(b.GetCurrentState(), STATE.NORMAL);
+});
+
+test('STATE_PRIORITY: monotonic ordering', () => {
+  assert.ok(STATE_PRIORITY[STATE.NORMAL] < STATE_PRIORITY[STATE.SPIN]);
+  assert.ok(STATE_PRIORITY[STATE.SPIN] < STATE_PRIORITY[STATE.SPLIT]);
+  assert.ok(STATE_PRIORITY[STATE.SPLIT] < STATE_PRIORITY[STATE.FINAL_SPLIT]);
+  assert.ok(STATE_PRIORITY[STATE.FINAL_SPLIT] < STATE_PRIORITY[STATE.EXPIRE]);
+});
+
+test('ChangeShrapnelState: forward transitions succeed', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.ChangeShrapnelState(STATE.SPLIT);
+  assert.equal(b.GetCurrentState(), STATE.SPLIT);
+});
+
+test('ChangeShrapnelState: backward transition is a no-op (monotonic guard)', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.ChangeShrapnelState(STATE.SPLIT);
+  b.ChangeShrapnelState(STATE.NORMAL);              // backward
+  assert.equal(b.GetCurrentState(), STATE.SPLIT, 'state stays at SPLIT');
+});
+
+test('ChangeShrapnelState: same-state transition is a no-op', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.ChangeShrapnelState(STATE.SPIN);
+  const spinStart = b._spinStartTime;
+  b.ChangeShrapnelState(STATE.SPIN);                // same
+  assert.equal(b._spinStartTime, spinStart, '_spinStartTime not reset');
+});
+
+test('ChangeShrapnelState: entering SPIN records timeElapsed as spinStartTime', () => {
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0,
+    spawnX: 0, spawnY: 0, extraParam: {},
+  });
+  b.timeElapsed = 1.5;
+  b.ChangeShrapnelState(STATE.SPIN);
+  assert.equal(b._spinStartTime, 1.5);
+});

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -74,8 +74,12 @@ test('Update: movement runs in NORMAL — position advances', () => {
   assert.equal(b.position.x, 10);
 });
 
-test('Update: range expiry fires in NORMAL (sets reachDestFlag)', () => {
-  // range 5 -> sqrRange 25; speed 10/tick -> expires in 1 tick.
+test('Update: range expiry in NORMAL transitions to SPLIT; empty groups -> EXPIRE next tick', () => {
+  // range 5 -> sqrRange 25; speed 10/tick -> range exceeded in 1 tick.
+  // Range expiry is the legacy ShrapnelBehavior's primary split trigger
+  // (apex is secondary, for gravity-bullets with vertical motion). With
+  // empty extraParam.shrapnel, SPLIT vacuously forwards to EXPIRE on the
+  // next tick.
   const b = new ShrapnelBulletUnit({
     velocity: 50, yAngle: 0, range: 5, rangeOffset: 0,
     spawnX: 0, spawnY: 0, extraParam: {},
@@ -84,6 +88,11 @@ test('Update: range expiry fires in NORMAL (sets reachDestFlag)', () => {
   b.InitSpeed();
   b.timeElapsed += TICK_SECONDS;
   b.Update();
+  assert.equal(b.GetCurrentState(), STATE.SPLIT, 'range expiry triggers SPLIT');
+  assert.equal(b.reachDestFlag, false, 'lattice not yet at EXPIRE');
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.equal(b.GetCurrentState(), STATE.EXPIRE);
   assert.equal(b.reachDestFlag, true);
 });
 

--- a/tests/physics/shrapnel.test.js
+++ b/tests/physics/shrapnel.test.js
@@ -386,3 +386,29 @@ test('fragile=1: SPLIT trigger emits no children but completes the lattice to EX
   // child specs.
   assert.equal(b.GetCurrentState(), STATE.EXPIRE);
 });
+
+test('flare: solves convertedVelocity and verticalSpeed to land on explodePos at child hit_type.time', () => {
+  // Pinpoint the formula:
+  //   childGrav = |-0.0005| = 0.0005, childHitTime = 60/30 s = 2 s, CALC_FPS = 30
+  //   spawnAlt = 0, dist = sqrt((10-0)^2 + 0^2) = 10
+  //   h = 0.5 * 0.0005 * (2*30)^2 - 0 = 0.5 * 0.0005 * 3600 = 0.9
+  //   convertedVelocity = sqrt(-0.5 * -0.0001 * 100 / 0.9) = sqrt(0.0055..) ~ 0.0745
+  //   t = 10 / 0.0745 = 134.16
+  //   verticalSpeed = 0.9 / 134.16 - 0.5 * -0.0001 * 134.16 = 0.00671 + 0.00671 = 0.01342
+  const childTpl = { extra_param: { gravity: -0.0005 }, hit_type: { time: 2 } };
+  const b = new ShrapnelBulletUnit({
+    velocity: 50, yAngle: 0, range: 100, rangeOffset: 0, gravity: -0.0001,
+    spawnX: 0, spawnY: 0,
+    extraParam: { flare: true, shrapnel: [{ bullet_ID: 'C', barrage_ID: 1 }] },
+    explodePos: { x: 10, y: 0 },
+    bulletTemplates: { C: childTpl },
+    barrages: { 1: { barrage_ID: 1, primal_repeat: 0, angle: 0, delta_angle: 0 } },
+  });
+  b.FixRange();
+  b.SetSpawnPosition();
+  // Tolerate small floating-point drift.
+  assert.ok(Math.abs(b._convertedVelocity - 0.07453559924999298) < 1e-6,
+    `expected ~0.0745, got ${b._convertedVelocity}`);
+  assert.ok(Math.abs(b.verticalSpeed - 0.01341640786499874) < 1e-6,
+    `expected ~0.01342, got ${b.verticalSpeed}`);
+});

--- a/tests/physics/world.test.js
+++ b/tests/physics/world.test.js
@@ -190,3 +190,78 @@ test('a plain cannon is unaffected by the curving machinery', () => {
   assert.equal(bullet.position.y, 0, 'a plain cannon flies dead straight');
   assert.equal(bullet.position.x, 20, 'velocity 50 * 0.2 = 10/tick, 2 ticks');
 });
+
+test('world.step drains drainEmits() into onEmit, after all Updates', () => {
+  const world = new World();
+  const events = [];
+  world.onEmit = (spec) => events.push(spec);
+
+  // Hand-rolled fake unit — emits two specs every tick.
+  const fake = {
+    timeElapsed: 0,
+    reachDestFlag: false,
+    Update() {},
+    drainEmits() {
+      const out = [{ id: 'a' }, { id: 'b' }];
+      return out;
+    },
+  };
+  world.bullets.push(fake);
+  world.step();
+  assert.deepEqual(events, [{ id: 'a' }, { id: 'b' }]);
+});
+
+test('world.step does NOT step a child spawned mid-tick (length-cached loop)', () => {
+  const world = new World();
+  let childStepped = false;
+  const child = {
+    timeElapsed: 0,
+    reachDestFlag: false,
+    Update() { childStepped = true; },
+  };
+  world.onEmit = () => { world.bullets.push(child); };
+
+  const parent = {
+    timeElapsed: 0,
+    reachDestFlag: false,
+    Update() {},
+    drainEmits() { return [{}]; },           // one emit -> spawns child
+  };
+  world.bullets.push(parent);
+  world.step();
+  assert.equal(childStepped, false, 'mid-tick child Update deferred to next step');
+  assert.ok(world.bullets.includes(child), 'child is queued for the next tick');
+});
+
+test('world.step still culls reachDestFlag units when onEmit is set', () => {
+  const world = new World();
+  world.onEmit = () => {};                   // no-op, just exercise the path
+  const dead = {
+    timeElapsed: 0,
+    reachDestFlag: false,
+    Update() { this.reachDestFlag = true; },
+  };
+  world.bullets.push(dead);
+  world.step();
+  assert.equal(world.bullets.length, 0);
+});
+
+test('world.step handles a reentrant onEmit that calls spawnBullet', () => {
+  const world = new World();
+  world.onEmit = (spec) => {
+    world.spawnBullet({
+      type: 1, velocity: 50, yAngle: 0, range: 10, rangeOffset: 0,
+      spawnX: spec.x, spawnY: spec.y,
+    });
+  };
+  const parent = {
+    timeElapsed: 0,
+    reachDestFlag: false,
+    Update() {},
+    drainEmits() { return [{ x: 0, y: 0 }]; },
+  };
+  world.bullets.push(parent);
+  world.step();
+  // parent stayed alive (no reachDestFlag); spawned child also alive.
+  assert.equal(world.bullets.length, 2);
+});


### PR DESCRIPTION
This PR migrates type-5 shrapnel (`ShrapnelBulletUnit`) and type-9 effect (`EffectBulletUnit`) bullets into the faithful physics core introduced in Phase 2/2b/2c. `ShrapnelBulletUnit` implements the monotonic `NORMAL→SPIN→SPLIT→FINAL_SPLIT→EXPIRE` state lattice from `battleshrapnelbulletunit.lua`, replacing the legacy path's unguarded boolean flags, non-existent `spinDuration`/`spinSpeed` fields, and wall-clock `setTimeout` scheduling. `EffectBulletUnit` adds a `hit_type.time` lifetime cap so type-9 bullets are culled when their design lifetime expires rather than lingering until range expiry (or forever). Phase 3b items — missile (13), scale (15), gravitation (11), non-airdrop bombs, curving gravity bullets — are not touched; the legacy `BehaviorFactory` continues to handle all predicate-rejected cases.

## Closed spec bugs

**§C6 shrapnel state lattice fidelity** — the legacy `ShrapnelBehavior` uses unguarded booleans (`triggered`, `isLingering`, `isSpinning`), invents `spinDuration`/`spinSpeed` fields that do not exist in any game data, schedules `shift_split_delay` via wall-clock `setTimeout` instead of game-time, and runs movement in every phase instead of gating it to NORMAL. These are replaced by the monotonic lattice with game-time scheduling.

**§C8 type-9 effect lifetime (spec bug #4 — "lingering red-dot")** — legacy path has no type-9 cleanup; the DOM element survives indefinitely. `EffectBulletUnit` flips `reachDestFlag` when `timeElapsed >= hit_type.time`, triggering the world's cull pass.

Note on visibility: after the Task 1 scan, none of the 26 reached type-9 bullets in the current skill set carry a `hit_type.time` that fires before range expiry — the spec's "visible bug" description is stale against current data. The implementation is correct and the cap will engage if future data introduces such a bullet. The 5 effect-unit tests confirm the cap logic.

## Test coverage

142 → 175 (33 new tests in Phase 3a):
- **5 effect tests** (`tests/physics/effect.test.js`) — lifetime cap variants.
- **~26 shrapnel tests** (`tests/physics/shrapnel.test.js`) — state lattice, trailing emission, split scheduling, fragile flag, SetSpawnPosition (gravity init + flare solver).
- **4 world tests** (`tests/physics/world.test.js`) — onEmit callback wiring, mid-tick child spawning (length-cached loop invariant), drainEmits per-step.
- **2 bullet-registry tests** — type 5 and type 9 registry entries.

## Strangler-fig predicates — legacy path still owns

Two new predicates (`_isMigratedEffect`, `_isMigratedShrapnel`) route Phase 3a types to the core. The legacy `BehaviorFactory` path continues to handle:

- **rangeAA shrapnel** (`extra_param.rangeAA` truthy) — AA-adjacent, out of scope per parent spec.
- **`out_bound === 3` (VISION) shrapnel** — covers the 6 reached VISION shrapnel including the 2 `directHit` cases found by the Task 1 data scan. The `directHit` branch in `ShrapnelBulletUnit.SetSpawnPosition` was not implemented since VISION shrapnel is predicate-rejected.
- **inheritSpeed shrapnel/effect** — legacy carries these.
- **transform-chained shrapnel/effect** — legacy carries these.
- **gravity-bearing bullets that are NOT shrapnel (type 5)** — the predicate `_isMigratedMovementBullet` still excludes gravity bullets from the cannon/stray/torpedo route.

## Browser verification

- **Shrapnel A — Kirishima skill 11270:** User-gated. Shrapnel arcs (gravity init applied), splits, emits children. Children show a "bounce up" at split that is at parity with the legacy `ShrapnelBehavior` on `main` — not a Phase 3a regression; flagged in the Phase 3b handoff for future investigation.
- **Shrapnel B — Trieste skill 5041:** User-gated; trailing/split timing verified in-page.
- **Type-9 (Minsk skill 4081):** Verified at parity with `main`. No visible change expected (the spec's "lingering" description is stale against current data).

## Data scan findings (Task 1)

- **`directHit` shrapnel (§C8):** 2 reached bullets, both carry `out_bound === 3` (VISION). Scoped out of Phase 3a — VISION shrapnel is predicate-rejected.
- **`fragile === 2`:** 0 reached bullets. Scoped out.
- **`inheritSpeed` shrapnel:** reached but stays on legacy path (predicate-rejected); not a regression.

## Files changed

- `public/js/simulators/physics/bullets/effect.js` — new: EffectBulletUnit
- `public/js/simulators/physics/bullets/shrapnel.js` — new: ShrapnelBulletUnit
- `public/js/simulators/physics/bullet-registry.js` — register types 5 and 9
- `public/js/simulators/physics/world.js` — add onEmit callback + length-cached step loop
- `public/js/simulators/sim.engine.bullet.js` — two new predicates, `world.onEmit` wiring, Phase 3a spawn opts forwarded in `_createWorldBullet`
- `tests/physics/effect.test.js`, `tests/physics/shrapnel.test.js` — new test files
- `tests/physics/world.test.js`, `tests/physics/bullet-registry.test.js` — additional tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
