### PR TITLE
feat(sim): Phase 3c — non-airdrop & curving bombs through physics core

### DIFF
--- a/public/js/simulators/physics/bullets/bomb.js
+++ b/public/js/simulators/physics/bullets/bomb.js
@@ -99,23 +99,25 @@ export class BombBulletUnit extends BulletUnit {
   }
 
   /**
-   * Aim the bomb from its spawn to the explode point and pick the movement
-   * function. Mirrors BattleBombBulletUnit.InitSpeed (battlebombbulletunit.lua:
-   * 15-25). getHeightAdjust spawns the bomb at the explode point's planar y, so
-   * the heading is 0 (or 180 for a left-facing host): the bomb drifts purely
-   * along x while verticalSpeed carries the descent. _barrageLowPriority is not
-   * modelled (0 airdrop bombs use it — Task 1).
+   * Aim the bomb (when an explodePos is supplied) and pick the movement
+   * function via the base priority chain. Mirrors BattleBombBulletUnit.InitSpeed
+   * (battlebombbulletunit.lua:15-25) plus the §B3 mutual-exclusivity rule:
+   * a bomb with HasAcceleration runs doAccelerate (gravity suppressed for those
+   * ticks because gravity integration lives inside doNothing).
+   *
+   * CRITICAL ORDERING: aim is set BEFORE super.InitSpeed() because the priority
+   * chain's doAccelerate branch seeds _speedNormal from yAngle.
+   *
+   * _barrageLowPriority is not modelled (0 reached bombs use it).
    */
   InitSpeed() {
-    // TODO(Phase 3c Task 4): null-guard for non-airdrop path; defer to super
-    // for priority chain. This dereferences explodePos unconditionally and
-    // will throw for non-airdrop bombs whose firing pipeline has no target.
-    this.yAngle = Math.atan2(
-      this.explodePos.y - this.spawnPos.y,
-      this.explodePos.x - this.spawnPos.x,
-    ) * DEG_PER_RAD;
-    this.calcSpeed();
-    this.updateSpeed = this.doNothing;
+    if (this.explodePos) {
+      this.yAngle = Math.atan2(
+        this.explodePos.y - this.spawnPos.y,
+        this.explodePos.x - this.spawnPos.x,
+      ) * DEG_PER_RAD;
+    }
+    super.InitSpeed();
   }
 
   /**

--- a/public/js/simulators/physics/bullets/bomb.js
+++ b/public/js/simulators/physics/bullets/bomb.js
@@ -26,7 +26,11 @@ export class BombBulletUnit extends BulletUnit {
     super(opts);
     // The base defaults gravity to 0; a bomb defaults to BattleConfig.GRAVITY.
     if (opts.gravity == null) this.gravity = GRAVITY;
-    this.explodePos = opts.explodePos ?? { x: 0, y: 0 };  // planar aim point
+    // Mode flag: airdrop (default true for back-compat) repositions the bomb
+    // above explodePos and aims at it; non-airdrop spawns at spawnX/spawnY
+    // (already placed by super) and aims at explodePos only if one is supplied.
+    this.airdrop = opts.airdrop ?? true;
+    this.explodePos = opts.explodePos ?? null;            // both modes; null = aim-by-yAngle
     this.direction = opts.direction ?? 1;                 // host facing (+1 / -1)
     this.offsetY = opts.offsetY ?? AIRCRAFT_HEIGHT;       // drop height; game uses host y
     this.dropOffset = opts.dropOffset ?? false;           // spawn behind the aim point?

--- a/public/js/simulators/physics/bullets/bomb.js
+++ b/public/js/simulators/physics/bullets/bomb.js
@@ -107,6 +107,9 @@ export class BombBulletUnit extends BulletUnit {
    * modelled (0 airdrop bombs use it — Task 1).
    */
   InitSpeed() {
+    // TODO(Phase 3c Task 4): null-guard for non-airdrop path; defer to super
+    // for priority chain. This dereferences explodePos unconditionally and
+    // will throw for non-airdrop bombs whose firing pipeline has no target.
     this.yAngle = Math.atan2(
       this.explodePos.y - this.spawnPos.y,
       this.explodePos.x - this.spawnPos.x,

--- a/public/js/simulators/physics/bullets/bomb.js
+++ b/public/js/simulators/physics/bullets/bomb.js
@@ -39,31 +39,54 @@ export class BombBulletUnit extends BulletUnit {
   }
 
   /**
-   * Resolve the airdrop spawn position. Mirrors getHeightAdjust
-   * (battlebullet.lua:226-239): an airdrop bomb spawns at `offsetY` altitude
-   * above the explode point and, with dropOffset set, behind it by
+   * Resolve the spawn geometry. Two modes:
+   *
+   * Airdrop (this.airdrop === true): mirrors getHeightAdjust
+   * (battlebullet.lua:226-239). The bomb spawns at `offsetY` altitude above
+   * the explode point and, with dropOffset set, behind it by
    *   sqrt(|2 * offsetY / gravity|) * convertedVelocity
-   * (the horizontal distance a projectile covers while falling offsetY),
-   * mirrored by host facing — then solves verticalSpeed so the descent passes
-   * through the explode point. Called once at spawn, before InitSpeed.
+   * mirrored by host facing. Then solves verticalSpeed for parabolic arrival.
+   *
+   * Non-airdrop: spawn position was already placed by base BulletUnit from
+   * spawnX/spawnY; altitude defaults to spawnAltitude (the firing weapon's
+   * altitude). If an explodePos was supplied, solves verticalSpeed for the
+   * parabola (battlebombbulletunit.lua:73-76). Without one, verticalSpeed
+   * stays 0 and the bomb falls under gravity only (doNothing).
    */
   SetSpawnPosition() {
-    const convertedVelocity = this.velocity * BULLET_SPEED_CONVERT;
-    const dropOffsetX = this.dropOffset
-      ? Math.sqrt(Math.abs(2 * this.offsetY / this.gravity))
-          * convertedVelocity * Math.sign(this.direction || 1)
-      : 0;
-    this.position = { x: this.explodePos.x - dropOffsetX, y: this.explodePos.y };
-    this.spawnPos = { x: this.position.x, y: this.position.y };
-    this.altitude = this.offsetY;
+    if (this.airdrop) {
+      const convertedVelocity = this.velocity * BULLET_SPEED_CONVERT;
+      const dropOffsetX = this.dropOffset
+        ? Math.sqrt(Math.abs(2 * this.offsetY / this.gravity))
+            * convertedVelocity * Math.sign(this.direction || 1)
+        : 0;
+      this.position = { x: this.explodePos.x - dropOffsetX, y: this.explodePos.y };
+      this.spawnPos = { x: this.position.x, y: this.position.y };
+      this.altitude = this.offsetY;
 
-    // SetSpawnPosition (battlebombbulletunit.lua:73-76): solve verticalSpeed
-    // so the parabola passes through the explode point at BOMB_DETONATE_HEIGHT.
-    // flightTime is in TICKS (convertedVelocity is per-tick displacement). The
-    // game's 3D distance keeps the explode point's vertical un-filtered, so the
-    // BOMB_DETONATE_HEIGHT term is load-bearing when the bomb is directly
-    // overhead (planar distance 0 — flightTime would otherwise be 0).
-    if (convertedVelocity !== 0) {
+      // SetSpawnPosition (battlebombbulletunit.lua:73-76): solve verticalSpeed
+      // so the parabola passes through the explode point at BOMB_DETONATE_HEIGHT.
+      // flightTime is in TICKS (convertedVelocity is per-tick displacement). The
+      // game's 3D distance keeps the explode point's vertical un-filtered, so the
+      // BOMB_DETONATE_HEIGHT term is load-bearing when the bomb is directly
+      // overhead (planar distance 0 — flightTime would otherwise be 0).
+      if (convertedVelocity !== 0) {
+        const flightTime = Math.sqrt(
+          sqrDistance(this.spawnPos, this.explodePos)
+          + BOMB_DETONATE_HEIGHT * BOMB_DETONATE_HEIGHT,
+        ) / convertedVelocity;
+        this.verticalSpeed = this.launchVrtSpeed != null
+          ? this.launchVrtSpeed
+          : (BOMB_DETONATE_HEIGHT - this.altitude) / flightTime
+            - 0.5 * this.gravity * flightTime;
+      }
+      return;
+    }
+
+    // Non-airdrop branch. position/spawnPos/altitude already set by super.
+    // Only the parabola solve runs, and only if an explodePos was supplied.
+    if (this.explodePos && this.velocity !== 0) {
+      const convertedVelocity = this.velocity * BULLET_SPEED_CONVERT;
       const flightTime = Math.sqrt(
         sqrDistance(this.spawnPos, this.explodePos)
         + BOMB_DETONATE_HEIGHT * BOMB_DETONATE_HEIGHT,

--- a/public/js/simulators/physics/world.js
+++ b/public/js/simulators/physics/world.js
@@ -50,24 +50,37 @@ export class World {
   }
 
   /**
-   * Create an airdrop bomb, resolve its airdrop spawn geometry and detonation,
-   * and add it to the simulation. Unlike spawnBullet, a bomb's spawn position
-   * is derived from its explode point — the firing pipeline supplies a planar
-   * explodePos — so this validates explodePos (and velocity) rather than
-   * spawnX/spawnY. Returns null on non-finite input. Precondition: opts.type is
-   * a registered bomb type (2 or 16); the sim.engine.bullet.js dispatch
-   * guarantees it.
+   * Create a bomb and add it to the simulation. Two modes:
+   *
+   * Airdrop (default): position derived from explodePos by BombBulletUnit's
+   * SetSpawnPosition; validates explodePos and velocity.
+   *
+   * Non-airdrop (opts.airdrop === false): position from spawnX/spawnY like
+   * spawnBullet; validates spawnX/spawnY/yAngle/velocity. explodePos may be
+   * null (bomb falls along yAngle). Returns null on non-finite input.
+   *
+   * Precondition: opts.type is a registered bomb type (2 or 16); the
+   * sim.engine.bullet.js dispatch guarantees it.
    */
   spawnBomb(opts) {
-    if (!Number.isFinite(opts.explodePos?.x) ||
-        !Number.isFinite(opts.explodePos?.y) ||
-        !Number.isFinite(opts.velocity)) {
-      return null;
+    if (opts.airdrop === false) {
+      if (!Number.isFinite(opts.spawnX) ||
+          !Number.isFinite(opts.spawnY) ||
+          !Number.isFinite(opts.yAngle) ||
+          !Number.isFinite(opts.velocity)) {
+        return null;
+      }
+    } else {
+      if (!Number.isFinite(opts.explodePos?.x) ||
+          !Number.isFinite(opts.explodePos?.y) ||
+          !Number.isFinite(opts.velocity)) {
+        return null;
+      }
     }
     const unit = createBulletUnit(opts.type, opts);
     unit.FixRange();
-    unit.SetSpawnPosition();   // airdrop geometry + vertical-speed solve
-    unit.InitSpeed();          // aim toward the explode point
+    unit.SetSpawnPosition();   // mode-branched inside BombBulletUnit
+    unit.InitSpeed();          // priority chain via base
     this.bullets.push(unit);
     return unit;
   }

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -179,7 +179,7 @@ export class BulletEngine {
         // explode point. An airdrop bomb with shrapnel / a transform chain
         // stays on the legacy path.
         if (this._isAirdropBomb(bulletInfo, options)) {
-            return this._createWorldBomb(options);
+            return this._createWorldBomb({ ...options, mode: 'airdrop' });
         }
 
         // Route a type-9 effect bullet to the faithful physics core — fixes
@@ -205,6 +205,13 @@ export class BulletEngine {
         // type-11 render branch below preserves the pulsing alert->active visual.
         if (this._isMigratedGravitation(bulletInfo, options)) {
             return this._createWorldBullet(options);
+        }
+
+        // Phase 3c: non-airdrop bombs (plain, timeToExplode, curving). Mutually
+        // exclusive with _isAirdropBomb on extra_param.airdrop, so insertion
+        // order vs the other predicates doesn't affect correctness.
+        if (this._isNonAirdropBomb(bulletInfo, options)) {
+            return this._createWorldBomb({ ...options, mode: 'non-airdrop' });
         }
 
         // Create bullet DOM element
@@ -749,30 +756,69 @@ export class BulletEngine {
     }
 
     /**
-     * Spawn an airdrop bomb into the physics core and build its DOM element.
-     * The core derives the bomb's spawn point, drop height and vertical speed
-     * from the explode point (airdropData.explodePos, in game coordinates), so
-     * — unlike _createWorldBullet — this path never reads the screen-space
-     * startX/startY. Returns the element, or null if the core rejected the
-     * spawn (non-finite input).
+     * Spawn a bomb into the physics core and build its DOM element. Two modes
+     * differ only in how the spawn point is derived; everything from spawnBomb
+     * onward (validation, FixRange, InitSpeed) is in BombBulletUnit /
+     * world.spawnBomb. The DOM tail is identical for both modes.
+     *
+     * - 'airdrop' (default for back-compat): airdropData.explodePos drives
+     *   SetSpawnPosition. Used by _isAirdropBomb hits.
+     * - 'non-airdrop': passes spawnX/spawnY/yAngle through like
+     *   _createWorldBullet, plus enemyTarget as the (nullable) explodePos.
+     *   Acceleration + barrageAngle + target flow through for curving bombs.
+     *   Used by _isNonAirdropBomb hits.
+     *
+     * Returns the element, or null if the core rejected the spawn (non-finite
+     * input).
      */
     _createWorldBomb(options) {
-        const { bulletInfo, airdropData } = options;
+        const { mode, bulletInfo } = options;
         const ep = bulletInfo.extra_param || {};
 
-        const unit = this.world.spawnBomb({
-            type: bulletInfo.type,
-            velocity: bulletInfo.velocity,
-            range: bulletInfo.range,
-            rangeOffset: bulletInfo.range_offset || 0,
-            gravity: ep.gravity,             // undefined -> BombBulletUnit uses GRAVITY
-            offsetY: ep.offsetY,             // undefined -> BombBulletUnit uses AIRCRAFT_HEIGHT
-            dropOffset: ep.dropOffset,
-            launchVrtSpeed: ep.launchVrtSpeed,
-            explodeTime: ep.timeToExplode,
-            explodePos: airdropData.explodePos,
-            direction: airdropData.direction,
-        });
+        let unit;
+        if (mode === 'non-airdrop') {
+            const { startX, startY, angle, barrageAngle, enemyTarget } = options;
+            const startGamePos = this.screenToGame(startX, startY);
+            unit = this.world.spawnBomb({
+                type: bulletInfo.type,
+                airdrop: false,
+                velocity: bulletInfo.velocity,
+                yAngle: angle,
+                range: bulletInfo.range,
+                rangeOffset: bulletInfo.range_offset || 0,
+                spawnX: startGamePos.x,
+                spawnY: startGamePos.y,
+                gravity: ep.gravity,
+                launchVrtSpeed: ep.launchVrtSpeed,
+                explodeTime: ep.timeToExplode,
+                explodePos: enemyTarget || null,
+                acceleration: bulletInfo.acceleration,
+                barrageAngle: barrageAngle,
+                target: enemyTarget,
+            });
+        } else {
+            // Airdrop path. The acceleration / barrageAngle / target fields
+            // are new to this path in Phase 3c — needed for curving airdrop
+            // bomb 170838. Plain airdrops have empty acceleration and ignore
+            // them via the base priority chain's fallback to doNothing.
+            const { airdropData } = options;
+            unit = this.world.spawnBomb({
+                type: bulletInfo.type,
+                velocity: bulletInfo.velocity,
+                range: bulletInfo.range,
+                rangeOffset: bulletInfo.range_offset || 0,
+                gravity: ep.gravity,             // undefined -> BombBulletUnit uses GRAVITY
+                offsetY: ep.offsetY,             // undefined -> BombBulletUnit uses AIRCRAFT_HEIGHT
+                dropOffset: ep.dropOffset,
+                launchVrtSpeed: ep.launchVrtSpeed,
+                explodeTime: ep.timeToExplode,
+                explodePos: airdropData.explodePos,
+                direction: airdropData.direction,
+                acceleration: bulletInfo.acceleration,
+                barrageAngle: options.barrageAngle,
+                target: options.enemyTarget,
+            });
+        }
         if (!unit) return null;
 
         const element = this._createBulletElement(bulletInfo);

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -12,7 +12,7 @@
 import { BehaviorFactory } from './sim.engine.bullet.factory.js';
 import { World } from './physics/world.js';
 import { drainAccumulator } from './physics/accumulator.js';
-import { TICK_SECONDS } from './physics/constants.js';
+import { TICK_SECONDS, AIRCRAFT_HEIGHT } from './physics/constants.js';
 
 /**
  * Bullet types routed through the faithful physics core (physics/). Cannon (1)
@@ -781,6 +781,12 @@ export class BulletEngine {
         if (mode === 'non-airdrop') {
             const { startX, startY, angle, barrageAngle, enemyTarget } = options;
             const startGamePos = this.screenToGame(startX, startY);
+            // spawnAltitude approximates the host weapon's deck altitude. Base
+            // BulletUnit defaults to 0, but the absolute-altitude detonation
+            // (`altitude <= BOMB_DETONATE_HEIGHT`) trips on tick 1 from altitude
+            // 0, so non-airdrop bombs need runway. ep.offsetY (set on some bomb
+            // templates as a host-altitude hint) wins; otherwise AIRCRAFT_HEIGHT
+            // is the same convention airdrop bombs use.
             unit = this.world.spawnBomb({
                 type: bulletInfo.type,
                 airdrop: false,
@@ -790,6 +796,7 @@ export class BulletEngine {
                 rangeOffset: bulletInfo.range_offset || 0,
                 spawnX: startGamePos.x,
                 spawnY: startGamePos.y,
+                spawnAltitude: ep.offsetY ?? AIRCRAFT_HEIGHT,
                 gravity: ep.gravity,
                 launchVrtSpeed: ep.launchVrtSpeed,
                 explodeTime: ep.timeToExplode,

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -174,10 +174,12 @@ export class BulletEngine {
             return this._createWorldBullet(options);
         }
 
-        // Route a plain airdrop bomb to the faithful physics core — the fix for
-        // the overhead-drop bugs: the bomb now falls from above onto its
-        // explode point. An airdrop bomb with shrapnel / a transform chain
-        // stays on the legacy path.
+        // Route a qualifying airdrop bomb to the faithful physics core — the
+        // fix for the overhead-drop bugs: the bomb now falls from above onto
+        // its explode point. Curving airdrop bombs (bullet 170838) are
+        // included as of Phase 3c (BombBulletUnit.InitSpeed defers to the
+        // base priority chain). An airdrop bomb with shrapnel / a transform
+        // chain stays on the legacy path.
         if (this._isAirdropBomb(bulletInfo, options)) {
             return this._createWorldBomb({ ...options, mode: 'airdrop' });
         }

--- a/public/js/simulators/sim.engine.bullet.js
+++ b/public/js/simulators/sim.engine.bullet.js
@@ -592,17 +592,19 @@ export class BulletEngine {
     }
 
     /**
-     * True only for a plain airdrop bomb the physics path provably renders
-     * correctly: a bomb type (2 / 16) flagged extra_param.airdrop, carrying the
-     * firing pipeline's airdropData (the explode point), with no acceleration
-     * data, shrapnel, missile, transform chain or inherited speed. An airdrop
-     * bomb with any of those stays on the legacy path.
+     * True only for an airdrop bomb the physics path provably renders
+     * correctly: a bomb type (2 / 16) flagged extra_param.airdrop, carrying
+     * the firing pipeline's airdropData (the explode point), with no shrapnel,
+     * missile, transform chain or inherited speed.
+     *
+     * Phase 3c relaxed the _hasEmptyAcceleration gate: curving airdrop bombs
+     * (1 reached, bullet 170838) now ride the base priority chain via
+     * BombBulletUnit.InitSpeed deferring to super.
      */
     _isAirdropBomb(bulletInfo, options) {
         return (bulletInfo.type === 2 || bulletInfo.type === 16)
             && bulletInfo.extra_param?.airdrop
             && options.airdropData != null
-            && this._hasEmptyAcceleration(bulletInfo)
             && !bulletInfo.extra_param?.shrapnel
             && !bulletInfo.extra_param?.missile
             && options.inheritSpeed == null
@@ -650,6 +652,24 @@ export class BulletEngine {
      */
     _isMigratedGravitation(bulletInfo, options) {
         return bulletInfo.type === 11
+            && options.inheritSpeed == null
+            && (!options.transformChain || options.transformChain.length === 0);
+    }
+
+    /**
+     * True for a non-airdrop bomb (type 2/16 without extra_param.airdrop)
+     * routed through the faithful physics core. Acceleration is welcome —
+     * BombBulletUnit.InitSpeed defers to the base priority chain, so
+     * doAccelerate fires for curving bombs (gravity is suppressed for those
+     * ticks, matching §B3 mutual exclusivity). Predicate-conservative:
+     *   - inheritSpeed and transform chains stay on legacy
+     *   - shrapnel and missile flags stay on legacy (orthogonal concerns)
+     */
+    _isNonAirdropBomb(bulletInfo, options) {
+        return (bulletInfo.type === 2 || bulletInfo.type === 16)
+            && !bulletInfo.extra_param?.airdrop
+            && !bulletInfo.extra_param?.shrapnel
+            && !bulletInfo.extra_param?.missile
             && options.inheritSpeed == null
             && (!options.transformChain || options.transformChain.length === 0);
     }

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -16,7 +16,7 @@
  * Must stay in sync with public/sw.js CACHE_VERSION. Bumping just one
  * leaves the other cache stale on first visit. See CLAUDE.md "Cache & Data Versioning".
  */
-const DATA_VERSION = '1.11.0';
+const DATA_VERSION = '1.12.0';
 
 /**
  * localStorage keys that participate in Google Drive sync.

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
 // See CLAUDE.md "Cache & Data Versioning" for the bump rules.
 // ============================================
 
-const CACHE_VERSION = '1.11.0';
+const CACHE_VERSION = '1.12.0';
 const STATIC_CACHE = `altoy-static-${CACHE_VERSION}`;
 const DATA_CACHE = `altoy-data-${CACHE_VERSION}`;
 

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -126,3 +126,21 @@ test('SetSpawnPosition: a velocity-0 bomb skips the vertical-speed solve and fal
   assert.equal(b.altitude, 8, 'spawn altitude = offsetY');
   assert.equal(b.verticalSpeed, 0, 'vertical-speed solve skipped — falls from rest');
 });
+
+test('constructor: airdrop defaults to true (back-compat for existing callers)', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, gravity: -0.25, offsetY: 8,
+    explodePos: { x: 20, y: 0 }, direction: 1,
+  });
+  assert.equal(b.airdrop, true, 'airdrop defaults to true');
+});
+
+test('constructor: airdrop:false is honored, explodePos may be null', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, airdrop: false, spawnX: 10, spawnY: 0, yAngle: 45,
+  });
+  assert.equal(b.airdrop, false);
+  assert.equal(b.explodePos, null, 'non-airdrop with no explodePos -> null');
+  assert.equal(b.position.x, 10, 'spawnX flowed through super');
+  assert.equal(b.yAngle, 45, 'yAngle flowed through super');
+});

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -164,3 +164,36 @@ test('SetSpawnPosition non-airdrop: spawnAltitude is honored when supplied', () 
   b.SetSpawnPosition();
   assert.equal(b.altitude, 15, 'host weapon altitude propagates from super');
 });
+
+test('SetSpawnPosition non-airdrop: parabola solve when explodePos is supplied', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, gravity: -0.25, airdrop: false,
+    spawnX: 0, spawnY: 0, explodePos: { x: 20, y: 0 },
+  });
+  b.SetSpawnPosition();
+  // convertedVelocity = 5 * 0.2 = 1.0
+  // flightTime = sqrt(20^2 + 1.2^2) / 1.0 = sqrt(401.44) ~= 20.036 ticks
+  // verticalSpeed = (1.2 - 0) / 20.036 - 0.5 * (-0.25) * 20.036
+  const flightTime = Math.sqrt(400 + 1.44);
+  const expected = (1.2 - 0) / flightTime - 0.5 * (-0.25) * flightTime;
+  assert.ok(Math.abs(b.verticalSpeed - expected) < 1e-9,
+    `non-airdrop parabola solve: expected ${expected}, got ${b.verticalSpeed}`);
+});
+
+test('SetSpawnPosition non-airdrop: launchVrtSpeed overrides the parabola solve', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, gravity: -0.25, airdrop: false,
+    spawnX: 0, spawnY: 0, explodePos: { x: 20, y: 0 }, launchVrtSpeed: -2,
+  });
+  b.SetSpawnPosition();
+  assert.equal(b.verticalSpeed, -2, 'explicit override wins over the solve');
+});
+
+test('SetSpawnPosition non-airdrop: velocity-0 skips the parabola solve', () => {
+  const b = new BombBulletUnit({
+    velocity: 0, gravity: -0.25, airdrop: false,
+    spawnX: 0, spawnY: 0, explodePos: { x: 20, y: 0 },
+  });
+  b.SetSpawnPosition();
+  assert.equal(b.verticalSpeed, 0, 'velocity 0 -> no solve, no division-by-zero');
+});

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { BombBulletUnit } from '../../public/js/simulators/physics/bullets/bomb.js';
+import { TICK_SECONDS } from '../../public/js/simulators/physics/constants.js';
 
 test('SetSpawnPosition: a no-dropOffset bomb spawns directly above the explode point', () => {
   const b = new BombBulletUnit({
@@ -229,4 +230,87 @@ test('InitSpeed with acceleration: priority chain picks doAccelerate', () => {
   b.InitSpeed();
   assert.equal(b.updateSpeed, b.doAccelerate,
     'HasAcceleration -> doAccelerate per the base priority chain');
+});
+
+test('curving non-airdrop bomb (shape of bullet 164461): horizontal arc, no gravity integration', () => {
+  // velocity=15, gravity=-0.05, acceleration=[{t:0.5, u:-1, v:0}]
+  // No explodePos -> verticalSpeed stays 0 -> flat trajectory.
+  const b = new BombBulletUnit({
+    velocity: 15, gravity: -0.05, airdrop: false,
+    spawnX: 0, spawnY: 0, yAngle: 0,
+    acceleration: [{ t: 0.5, u: -1, v: 0, flip: false }],
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  // Initial: convertedVelocity = 15 * 0.2 = 3.0 along +x.
+  assert.equal(b.speed.x, 3.0);
+  assert.equal(b.verticalSpeed, 0);
+
+  // Ticks 1-15: acceleration record inactive (t=0.5 > timeElapsed).
+  // Floating-point note: accumulated 15*(1/30) = 0.49999...994 < 0.5, so the
+  // record does NOT activate until tick 16 (timeElapsed ≈ 0.5333 > 0.5).
+  // Speed unchanged; verticalSpeed STAYS 0 even though gravity=-0.05.
+  for (let i = 0; i < 15; i++) {
+    b.timeElapsed += TICK_SECONDS;
+    b.Update();
+  }
+  // After 15 ticks: timeElapsed ≈ 0.4999...994 (still < 0.5 due to float accumulation)
+  assert.ok(Math.abs(b.speed.x - 3.0) < 1e-9, 'forward speed unchanged before t=0.5');
+  assert.equal(b.verticalSpeed, 0, '§B3: gravity suppressed because doAccelerate runs');
+  assert.equal(b.altitude, 0, 'altitude unchanged when verticalSpeed is 0');
+
+  // Tick 16: timeElapsed ≈ 0.5333 > 0.5. Record activates (Lua: t <= timeElapsed).
+  // Note: accumulated float arithmetic means the t=0.5 boundary is first crossed
+  // at tick 16, not tick 15 (15*(1/30) underflows 0.5 by ~6e-18).
+  b.timeElapsed += TICK_SECONDS;
+  b.Update();
+  assert.ok(Math.abs(b.speed.x - 2.0) < 1e-9,
+    'tick 16: u=-1 decays forward speed by 1');
+  assert.equal(b.verticalSpeed, 0, 'still no gravity integration');
+});
+
+test('curving non-airdrop bomb: acceleration record activates at t=0.5 exactly (boundary)', () => {
+  // Direct boundary test mirroring the Phase 3b lesson: GetAcceleration uses
+  // rec.t <= timeElapsed. At timeElapsed === 0.5 the {t:0.5} record is active.
+  const b = new BombBulletUnit({
+    velocity: 15, airdrop: false, spawnX: 0, spawnY: 0, yAngle: 0,
+    acceleration: [{ t: 0.5, u: -1, v: 0, flip: false }],
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  b.timeElapsed = 0.5;
+  const before = b.speed.x;
+  b.Update();
+  assert.ok(before - b.speed.x > 0.9, 'record active at t=0.5 (boundary inclusive)');
+});
+
+test('curving airdrop bomb (shape of bullet 170838): launchVrtSpeed override + horizontal decel', () => {
+  // velocity=1.5, gravity=-0.05, acceleration=[{t:0.1, u:-0.3, v:0}],
+  // launchVrtSpeed=-3, offsetY=60. Airdrop spawn: altitude=60, verticalSpeed=-3.
+  const b = new BombBulletUnit({
+    velocity: 1.5, gravity: -0.05, airdrop: true,
+    offsetY: 60, launchVrtSpeed: -3, dropOffset: false,
+    explodePos: { x: 100, y: 0 }, direction: 1,
+    acceleration: [{ t: 0.1, u: -0.3, v: 0, flip: false }],
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  assert.equal(b.altitude, 60, 'airdrop spawn altitude');
+  assert.equal(b.verticalSpeed, -3, 'launchVrtSpeed override beats parabola solve');
+  assert.equal(b.updateSpeed, b.doAccelerate, 'HasAcceleration -> doAccelerate');
+
+  // Ticks 0-2: acceleration record inactive (t=0.1 > timeElapsed for i<3).
+  // verticalSpeed stays -3, altitude drops 3/tick. Forward speed unchanged.
+  const initialSpeedX = b.speed.x;
+  for (let i = 0; i < 3; i++) {
+    b.timeElapsed += TICK_SECONDS;
+    b.Update();
+  }
+  // After 3 ticks: timeElapsed = 3/30 = 0.1 exactly -> record activates THIS tick.
+  // So: ticks 0-2 had inactive record (early-out); tick 3 (= the 3rd Update call)
+  // had timeElapsed=0.1 going in, record active, forward speed decays by 0.3.
+  assert.ok(Math.abs(b.speed.x - (initialSpeedX - 0.3)) < 1e-9,
+    'record activates at t=0.1 boundary, forward speed decays by 0.3');
+  assert.equal(b.verticalSpeed, -3, 'verticalSpeed frozen at launchVrtSpeed');
+  assert.equal(b.altitude, 60 - 3 * 3, 'altitude dropped by 3 per tick (3 ticks)');
 });

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -197,3 +197,36 @@ test('SetSpawnPosition non-airdrop: velocity-0 skips the parabola solve', () => 
   b.SetSpawnPosition();
   assert.equal(b.verticalSpeed, 0, 'velocity 0 -> no solve, no division-by-zero');
 });
+
+test('InitSpeed non-airdrop with no explodePos: yAngle preserved from caller', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, gravity: -0.05, airdrop: false,
+    spawnX: 0, spawnY: 0, yAngle: 30,
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  assert.equal(b.yAngle, 30, 'no explodePos -> no override, yAngle from caller stands');
+  assert.equal(b.updateSpeed, b.doNothing, 'no acceleration -> doNothing (gravity integrator)');
+});
+
+test('InitSpeed non-airdrop with explodePos: yAngle overridden to aim', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, gravity: -0.05, airdrop: false,
+    spawnX: 0, spawnY: 0, yAngle: 30, explodePos: { x: 10, y: 10 },
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  assert.equal(b.yAngle, 45, 'atan2(10-0, 10-0) * 180/pi = 45');
+});
+
+test('InitSpeed with acceleration: priority chain picks doAccelerate', () => {
+  const b = new BombBulletUnit({
+    velocity: 15, gravity: -0.05, airdrop: false,
+    spawnX: 0, spawnY: 0, yAngle: 0,
+    acceleration: [{ t: 0.5, u: -1, v: 0, flip: false }],
+  });
+  b.SetSpawnPosition();
+  b.InitSpeed();
+  assert.equal(b.updateSpeed, b.doAccelerate,
+    'HasAcceleration -> doAccelerate per the base priority chain');
+});

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -144,3 +144,23 @@ test('constructor: airdrop:false is honored, explodePos may be null', () => {
   assert.equal(b.position.x, 10, 'spawnX flowed through super');
   assert.equal(b.yAngle, 45, 'yAngle flowed through super');
 });
+
+test('SetSpawnPosition non-airdrop: no reposition, no parabola solve when explodePos is null', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, airdrop: false, spawnX: 10, spawnY: 7, yAngle: 30,
+    gravity: -0.05,
+  });
+  b.SetSpawnPosition();
+  assert.deepEqual(b.position, { x: 10, y: 7 }, 'spawn position unchanged');
+  assert.deepEqual(b.spawnPos, { x: 10, y: 7 });
+  assert.equal(b.altitude, 0, 'altitude defaults to spawnAltitude (0)');
+  assert.equal(b.verticalSpeed, 0, 'no explodePos -> no parabola solve');
+});
+
+test('SetSpawnPosition non-airdrop: spawnAltitude is honored when supplied', () => {
+  const b = new BombBulletUnit({
+    velocity: 5, airdrop: false, spawnX: 0, spawnY: 0, spawnAltitude: 15,
+  });
+  b.SetSpawnPosition();
+  assert.equal(b.altitude, 15, 'host weapon altitude propagates from super');
+});

--- a/tests/physics/bomb.test.js
+++ b/tests/physics/bomb.test.js
@@ -216,7 +216,7 @@ test('InitSpeed non-airdrop with explodePos: yAngle overridden to aim', () => {
   });
   b.SetSpawnPosition();
   b.InitSpeed();
-  assert.equal(b.yAngle, 45, 'atan2(10-0, 10-0) * 180/pi = 45');
+  assert.equal(b.yAngle, 45, 'atan2(dy=10, dx=10) * 180/pi = 45');
 });
 
 test('InitSpeed with acceleration: priority chain picks doAccelerate', () => {

--- a/tests/physics/world.test.js
+++ b/tests/physics/world.test.js
@@ -265,3 +265,41 @@ test('world.step handles a reentrant onEmit that calls spawnBullet', () => {
   // parent stayed alive (no reachDestFlag); spawned child also alive.
   assert.equal(world.bullets.length, 2);
 });
+
+test('spawnBomb non-airdrop validates spawnX/spawnY/yAngle/velocity', () => {
+  const world = new World();
+  // NaN spawnX -> reject.
+  const a = world.spawnBomb({
+    type: 2, airdrop: false, velocity: 5, yAngle: 0,
+    spawnX: NaN, spawnY: 0, range: 50, rangeOffset: 0,
+  });
+  assert.equal(a, null);
+  assert.equal(world.bullets.length, 0);
+
+  // NaN velocity -> reject.
+  const b = world.spawnBomb({
+    type: 2, airdrop: false, velocity: NaN, yAngle: 0,
+    spawnX: 0, spawnY: 0, range: 50, rangeOffset: 0,
+  });
+  assert.equal(b, null);
+});
+
+test('spawnBomb non-airdrop with null explodePos succeeds (falls along yAngle)', () => {
+  const world = new World();
+  const b = world.spawnBomb({
+    type: 2, airdrop: false, velocity: 5, yAngle: 0,
+    spawnX: 0, spawnY: 0, range: 50, rangeOffset: 0,
+    gravity: -0.05, explodePos: null,
+  });
+  assert.ok(b, 'spawn succeeds with null explodePos');
+  assert.equal(world.bullets.length, 1);
+  assert.equal(b.yAngle, 0, 'yAngle preserved from caller (no aim override)');
+});
+
+test('spawnBomb airdrop validation still rejects NaN explodePos (regression)', () => {
+  const world = new World();
+  const b = world.spawnBomb({
+    type: 2, velocity: 5, explodePos: { x: NaN, y: 0 },
+  });
+  assert.equal(b, null);
+});


### PR DESCRIPTION
## Summary

Migrates ~198 reached bomb variants from the legacy `BehaviorFactory` to
the physics core: 194 plain non-airdrop bombs, 3 reached curving
non-airdrop bombs (`164461` / `164470`, fired by 모가도르), and 1 curving
airdrop bomb (`170838`, fired by 어드벤처).

Single-class refactor of `BombBulletUnit` adds an `airdrop` mode flag;
`SetSpawnPosition` branches on it; `InitSpeed` defers to the base
priority chain so `HasAcceleration → doAccelerate` works for curving
bombs. The §B3 mutual-exclusivity (gravity suppressed for accelerating
ticks) is structural — no new code; gravity integration already lives
only inside `doNothing`, so a bomb that picks `doAccelerate` skips
gravity automatically.

## Spec & plan

- Design: `dev/active/2026-05-21-phase3c-design.md`
- Plan:   `dev/active/2026-05-21-phase3c-plan.md`
- §D3 addendum to parent spec (Phase 3b gravitation-stationary
  correction) at `dev/active/2026-05-17-weapon-physics-rework.md:164`.

## Tests

Baseline 201 → 217 (+16 across `bomb.test.js` and `world.test.js`).
Covers: non-airdrop spawn (with/without explodePos), parabola solve,
launchVrtSpeed override, velocity-0 division guard, curving non-airdrop
composition (bullet 164461 shape), curving airdrop composition (bullet
170838 shape), inclusive `<=` boundary at `t=0.5`, timeToExplode
interaction, regression guard for all 8 pre-existing airdrop tests.

## Browser spotcheck findings

- **펜실베이니아 (10130) plain non-airdrop:** initial spotcheck found
  bombs detonating instantly (1-tick red-dot glimpse). Root cause: the
  engine's non-airdrop branch was passing `spawnX/spawnY` but no
  `spawnAltitude`, so the base `BulletUnit` defaulted altitude to 0, and
  the absolute-altitude detonation check (`altitude <= 1.2`) tripped on
  tick 1. Fix in commit `5a9b074`: pass `spawnAltitude: ep.offsetY ??
  AIRCRAFT_HEIGHT`. Re-verified arcing forward over ~0.6s.
- **모가도르 (17940) curving non-airdrop:** confirmed flat trajectory +
  horizontal deceleration after t=0.5s.
- **어드벤처 (30541) curving airdrop:** sim depicts spawn-above-target
  → forward decel → `reverseAcceleration` bounce → resume forward. This
  is Lua-faithful per the tick-math walk-through (see PR review
  comments). Visual comparison against the in-game submarine skill was
  deferred — it's the only reached skill firing bullet 170838, no
  alternative exists in the corpus.

## Open items / followups

- §B8 absolute-altitude convention vs. host-altitude: the
  `spawnAltitude: ep.offsetY ?? AIRCRAFT_HEIGHT` fallback is an
  approximation of host deck altitude — the firing pipeline doesn't
  surface the real host y. Sufficient for visible-arc fidelity; flagged
  as a possible future tightening if `extra_param.offsetY` semantics on
  non-airdrop bombs turn out to mean something else.
- The plan's CACHE_VERSION-only bump was inaccurate; `scripts/check-
  versions.mjs` enforces `CACHE_VERSION === DATA_VERSION`. Implementer
  correctly dual-bumped both to 1.12.0. CLAUDE.md / future plans should
  treat them as a single dual-bump step.
- The final-phase cleanup (delete `BehaviorFactory`'s bomb dispatch and
  `GravityBehavior._tryAimedTrajectory`) becomes possible once the
  remaining excluded variants (`rangeAA`, `inheritSpeed`,
  `transformChain`, `shrapnel`, `missile`) migrate. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)